### PR TITLE
Corrected advance key in MD files.

### DIFF
--- a/tests/content/entity/light/point/create/test.md
+++ b/tests/content/entity/light/point/create/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/light/spot/create/test.md
+++ b/tests/content/entity/light/spot/create/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/material/apply/avatars/test.md
+++ b/tests/content/entity/material/apply/avatars/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/material/apply/entities/model/test.md
+++ b/tests/content/entity/material/apply/entities/model/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/material/apply/entities/shape/test.md
+++ b/tests/content/entity/material/apply/entities/shape/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/material/apply/overlays/model/test.md
+++ b/tests/content/entity/material/apply/overlays/model/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/material/create/test.md
+++ b/tests/content/entity/material/create/test.md
@@ -5,28 +5,45 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
 - ![](./ExpectedImage_00000.png)
 ### Step 2
-- Take snapshot
-- ![](./ExpectedImage_00001.png)
+- Debug Emissive
 ### Step 3
 - Take snapshot
-- ![](./ExpectedImage_00002.png)
+- ![](./ExpectedImage_00001.png)
 ### Step 4
-- Take snapshot
-- ![](./ExpectedImage_00003.png)
+- Debug Albedo
 ### Step 5
 - Take snapshot
-- ![](./ExpectedImage_00004.png)
+- ![](./ExpectedImage_00002.png)
 ### Step 6
-- Take snapshot
-- ![](./ExpectedImage_00005.png)
+- Debug Metallic
 ### Step 7
 - Take snapshot
-- ![](./ExpectedImage_00006.png)
+- ![](./ExpectedImage_00003.png)
 ### Step 8
+- Debug Roughness
+### Step 9
 - Take snapshot
+- ![](./ExpectedImage_00004.png)
+### Step 10
+- Debug Normal
+### Step 11
+- Take snapshot
+- ![](./ExpectedImage_00005.png)
+### Step 12
+- Debug Occlusion
+### Step 13
+- Take snapshot
+- ![](./ExpectedImage_00006.png)
+### Step 14
+- Debug Scattering
+### Step 15
+- Take snapshot
+- ![](./ExpectedImage_00007.png)
+### Step 16
+- Clean up after test

--- a/tests/content/entity/shape/create/test.md
+++ b/tests/content/entity/shape/create/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot of all the models
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/zone/ambientLightInheritance/test.md
+++ b/tests/content/entity/zone/ambientLightInheritance/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Red zone, bright ambient light

--- a/tests/content/entity/zone/ambientLightZoneEffects/test.md
+++ b/tests/content/entity/zone/ambientLightZoneEffects/test.md
@@ -5,19 +5,21 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
-- Moving forward
-- ![](./ExpectedImage_00000.png)
+- Setup camera position
 ### Step 2
 - Moving forward
-- ![](./ExpectedImage_00001.png)
+- ![](./ExpectedImage_00000.png)
 ### Step 3
+- Moving forward
+- ![](./ExpectedImage_00001.png)
+### Step 4
 - Moving forward and right
 - ![](./ExpectedImage_00002.png)
-### Step 4
+### Step 5
 - Moving left
 - ![](./ExpectedImage_00003.png)
-### Step 5
+### Step 6
 - Cleanup

--- a/tests/content/entity/zone/create/test.md
+++ b/tests/content/entity/zone/create/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/content/entity/zone/zoneOrientation/test.md
+++ b/tests/content/entity/zone/zoneOrientation/test.md
@@ -5,49 +5,48 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Zone not rotated - keylight at zenith
-- ![](./ExpectedImage_00000.png)
 ### Step 2
 - Pitch zone 45 degrees up, light should come from behind, 45 degrees above horizon
-- ![](./ExpectedImage_00001.png)
+- ![](./ExpectedImage_00000.png)
 ### Step 3
 - Add yaw zone 90 degrees clockwise, light should come from left, 45 degrees above horizon
-- ![](./ExpectedImage_00002.png)
+- ![](./ExpectedImage_00001.png)
 ### Step 4
 - Add roll zone 45 degrees clockwise, light should come from left
-- ![](./ExpectedImage_00003.png)
+- ![](./ExpectedImage_00002.png)
 ### Step 5
 - Zone not rotated - sun straight ahead on purple background (sphere is hidden)
-- ![](./ExpectedImage_00004.png)
+- ![](./ExpectedImage_00003.png)
 ### Step 6
 - Yaw zone 15 degrees right, sun should move right
-- ![](./ExpectedImage_00005.png)
+- ![](./ExpectedImage_00004.png)
 ### Step 7
 - Pitch zone 15 degrees up, yaw zone 15 degrees right, sun should move right and up
-- ![](./ExpectedImage_00006.png)
+- ![](./ExpectedImage_00005.png)
 ### Step 8
 - Pitch zone 15 degrees up, yaw zone 15 degrees right and roll 45 degrees, sun should move straight up
-- ![](./ExpectedImage_00007.png)
+- ![](./ExpectedImage_00006.png)
 ### Step 9
 - Zone not rotated - diffuse sphere and metallic object visible (skybox still enabled as a visual aid)
-- ![](./ExpectedImage_00008.png)
+- ![](./ExpectedImage_00007.png)
 ### Step 10
 - Yaw 90 degrees - blue is now behind
-- ![](./ExpectedImage_00009.png)
+- ![](./ExpectedImage_00008.png)
 ### Step 11
 - Yaw 180 degrees - purple is now behind
-- ![](./ExpectedImage_00010.png)
+- ![](./ExpectedImage_00009.png)
 ### Step 12
 - Yaw 270 degrees - red is now behind
-- ![](./ExpectedImage_00011.png)
+- ![](./ExpectedImage_00010.png)
 ### Step 13
 - Pitch 90 - green is now behind
-- ![](./ExpectedImage_00012.png)
+- ![](./ExpectedImage_00011.png)
 ### Step 14
 - Roll 45 degrees - green top-left, red top-right, yellow bottom-right, blue bottom-left
-- ![](./ExpectedImage_00013.png)
+- ![](./ExpectedImage_00012.png)
 ### Step 15
 - Cleanup

--- a/tests/engine/interaction/pointer/laser/centerEndY/test.md
+++ b/tests/engine/interaction/pointer/laser/centerEndY/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Running LaserPointer centerEndY test
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/engine/interaction/pointer/laser/distanceScaleEnd/test.md
+++ b/tests/engine/interaction/pointer/laser/distanceScaleEnd/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Minimum distance
@@ -15,3 +15,6 @@ Press space bar to advance step by step
 - ![](./ExpectedImage_00001.png)
 ### Step 3
 - Maximum distance
+- ![](./ExpectedImage_00002.png)
+### Step 4
+- Clean up

--- a/tests/engine/interaction/pointer/laser/enable/test.md
+++ b/tests/engine/interaction/pointer/laser/enable/test.md
@@ -5,10 +5,13 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Enabled right laser
 - ![](./ExpectedImage_00000.png)
 ### Step 2
 - Enabled left laser
+- ![](./ExpectedImage_00001.png)
+### Step 3
+- Clean up

--- a/tests/engine/interaction/pointer/laser/faceAvatar/test.md
+++ b/tests/engine/interaction/pointer/laser/faceAvatar/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - 1st position

--- a/tests/engine/interaction/pointer/laser/ignore/test.md
+++ b/tests/engine/interaction/pointer/laser/ignore/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - 1st position

--- a/tests/engine/interaction/pointer/laser/lockEnd/test.md
+++ b/tests/engine/interaction/pointer/laser/lockEnd/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - 1st Position

--- a/tests/engine/interaction/pointer/laser/lockEndUUID/test.md
+++ b/tests/engine/interaction/pointer/laser/lockEndUUID/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Attached to left
@@ -15,3 +15,6 @@ Press space bar to advance step by step
 - ![](./ExpectedImage_00001.png)
 ### Step 3
 - Attached to right
+- ![](./ExpectedImage_00002.png)
+### Step 4
+- Clean up

--- a/tests/engine/interaction/pointer/laser/renderState/test.md
+++ b/tests/engine/interaction/pointer/laser/renderState/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Not attached
@@ -24,3 +24,6 @@ Press space bar to advance step by step
 - ![](./ExpectedImage_00004.png)
 ### Step 6
 - Attached red - state 5
+- ![](./ExpectedImage_00005.png)
+### Step 7
+- Clean up

--- a/tests/engine/render/antialiasing/test.md
+++ b/tests/engine/render/antialiasing/test.md
@@ -5,10 +5,9 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Anti-aliased image
-- ![](./ExpectedImage_00000.png)
 ### Step 2
 - Clean up after test

--- a/tests/engine/render/effect/bloom/test.md
+++ b/tests/engine/render/effect/bloom/test.md
@@ -5,13 +5,12 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Bloom is off - no bloom should be visible
-- ![](./ExpectedImage_00000.png)
 ### Step 2
 - Bloom enabled
-- ![](./ExpectedImage_00001.png)
+- ![](./ExpectedImage_00000.png)
 ### Step 3
 - Clean up

--- a/tests/engine/render/effect/haze/color/test.md
+++ b/tests/engine/render/effect/haze/color/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/glare_large/test.md
+++ b/tests/engine/render/effect/haze/glare_large/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/glare_small/test.md
+++ b/tests/engine/render/effect/haze/glare_small/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/high_range/test.md
+++ b/tests/engine/render/effect/haze/high_range/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/low_range/test.md
+++ b/tests/engine/render/effect/haze/low_range/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/low_range_high_base_low_ceiling/test.md
+++ b/tests/engine/render/effect/haze/low_range_high_base_low_ceiling/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/low_range_high_ceiling/test.md
+++ b/tests/engine/render/effect/haze/low_range_high_ceiling/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/low_range_low_ceiling/test.md
+++ b/tests/engine/render/effect/haze/low_range_low_ceiling/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/none/test.md
+++ b/tests/engine/render/effect/haze/none/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/partial_sky/test.md
+++ b/tests/engine/render/effect/haze/partial_sky/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/haze/visible_sky/test.md
+++ b/tests/engine/render/effect/haze/visible_sky/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/effect/highlight/coverage/test.md
+++ b/tests/engine/render/effect/highlight/coverage/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Step 1
@@ -42,3 +42,6 @@ Press space bar to advance step by step
 - ![](./ExpectedImage_00010.png)
 ### Step 12
 - Take snapshot
+- ![](./ExpectedImage_00011.png)
+### Step 13
+- Clean up after test

--- a/tests/engine/render/geometry/invalidURL/test.md
+++ b/tests/engine/render/geometry/invalidURL/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Attempt to load model with invalid URL

--- a/tests/engine/render/lighting/ponctual/onTransparent/test.md
+++ b/tests/engine/render/lighting/ponctual/onTransparent/test.md
@@ -5,7 +5,10 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Take snapshot
+- ![](./ExpectedImage_00000.png)
+### Step 2
+- Clean up after test

--- a/tests/engine/render/material/albedo/test.md
+++ b/tests/engine/render/material/albedo/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/material/base/test.md
+++ b/tests/engine/render/material/base/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/material/emissive/test.md
+++ b/tests/engine/render/material/emissive/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/material/normal_map/test.md
+++ b/tests/engine/render/material/normal_map/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/material/opacity/test.md
+++ b/tests/engine/render/material/opacity/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/material/roughness/test.md
+++ b/tests/engine/render/material/roughness/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/material/roughness_map/test.md
+++ b/tests/engine/render/material/roughness_map/test.md
@@ -5,7 +5,7 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Clean up after test

--- a/tests/engine/render/shadows/front/test.md
+++ b/tests/engine/render/shadows/front/test.md
@@ -5,10 +5,9 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Light source altitude: 20.0, azimuth: 180.0
-- ![](./ExpectedImage_00000.png)
 ### Step 2
 - Clean up after test

--- a/tests/engine/render/shadows/grazing/test.md
+++ b/tests/engine/render/shadows/grazing/test.md
@@ -5,10 +5,9 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Light source altitude: 5.0, azimuth: 90.0
-- ![](./ExpectedImage_00000.png)
 ### Step 2
 - Clean up after test

--- a/tests/engine/render/shadows/normal/test.md
+++ b/tests/engine/render/shadows/normal/test.md
@@ -5,10 +5,9 @@
 - In an empty region of a domain with editing rights.
 
 ## Steps
-Press space bar to advance step by step
+Press 'n' key to advance step by step
 
 ### Step 1
 - Light source altitude: 80.0, azimuth: -60.0
-- ![](./ExpectedImage_00000.png)
 ### Step 2
 - Clean up after test


### PR DESCRIPTION
This PR updated the MD files to use `n` as the step advance key, for manual testing.