### PR TITLE
Do not store previous camera selection between sessions.

### DIFF
--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -194,7 +194,7 @@ module.exports.setupTest = function (primaryCamera) {
     //
     // Find location of "tests"
     var testsIndex;
-    for (testsIndex = pathParts.length - 1; pathParts > 0; --pathParts) {
+    for (testsIndex = pathParts.length - 1; pathParts > 0; --testsIndex) {
         if (pathParts[testsIndex] === "tests") {
             break;
         }

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -194,7 +194,7 @@ module.exports.setupTest = function (primaryCamera) {
     //
     // Find location of "tests"
     var testsIndex;
-    for (testsIndex = pathParts - 1; pathParts > 0; --pathParts) {
+    for (testsIndex = pathParts.length - 1; pathParts > 0; --pathParts) {
         if (pathParts[testsIndex] === "tests") {
             break;
         }

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -192,9 +192,10 @@ module.exports.setupTest = function (primaryCamera) {
     // Date and time are not used as part of the name, to keep the path lengths to a minimum
     // (the Windows API limit is 260 characters).
     //
+    // Find location of "tests"
     var testsIndex;
     for (testsIndex = pathParts - 1; pathParts > 0; --pathParts) {
-        if (pathParts[testIndex] === "tests") {
+        if (pathParts[testsIndex] === "tests") {
             break;
         }
     }

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -194,7 +194,7 @@ module.exports.setupTest = function (primaryCamera) {
     //
     // Find location of "tests"
     var testsIndex;
-    for (testsIndex = pathParts.length - 1; pathParts > 0; --testsIndex) {
+    for (testsIndex = pathParts.length - 1; testsIndex > 0; --testsIndex) {
         if (pathParts[testsIndex] === "tests") {
             break;
         }

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -202,7 +202,8 @@ module.exports.setupTest = function (primaryCamera) {
     
     snapshotPrefix = pathParts[testsIndex];
     for (var i = testsIndex + 1; i < pathParts.length; ++i) {
-        snapshotPrefix += pathSeparator + pathParts[i];
+        var str = pathParts[i];
+        snapshotPrefix += pathSeparator + str;
     }
 
     snapshotIndex = 0;

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -219,9 +219,7 @@ module.exports.setupTest = function (primaryCamera) {
     spectatorCameraConfig.position = {x: MyAvatar.position.x, y: MyAvatar.position.y + 0.6, z: MyAvatar.position.z};
     spectatorCameraConfig.orientation = MyAvatar.orientation;
 
-    if (primaryCamera) {
-        usePrimaryCamera = true;
-    }
+    usePrimaryCamera = (primaryCamera !== undefined && primaryCamera);
 
     return spectatorCameraConfig;
 }

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -187,23 +187,21 @@ module.exports.setupTest = function (primaryCamera) {
     
     // Snapshots are saved in the user-selected folder
     // For a test running from D:/GitHub/hifi-tests/tests/content/entity/zone/create/tests.js
-    // the tests are named D.GitHub.hifi-tests.tests.content.entity.zone.create.00000.jpg and so on
+    // the tests are named tests.content.entity.zone.create.00000.jpg and so on
     // (assuming pathSeparator is ".")
     // Date and time are not used as part of the name, to keep the path lengths to a minimum
     // (the Windows API limit is 260 characters).
     //
-    snapshotPrefix = "";
-
-    // On Windows the first part is <disk>: - this is changed
-    var str = pathParts[0];
-    if (str.indexOf(":") !== -1) {
-        snapshotPrefix = str.replace(":", "").toUpperCase();
+    var testsIndex;
+    for (testsIndex = pathParts - 1; pathParts > 0; --pathParts) {
+        if (pathParts[testIndex] === "tests") {
+            break;
+        }
     }
-
-    for (var i = 1; i < pathParts.length; ++i) {
-        str = pathParts[i];
-        
-        snapshotPrefix += pathSeparator + str;
+    
+    snapshotPrefix = pathParts[testIndex]
+    for (var i = testsIndex + 1; i < pathParts.length; ++i) {
+        snapshotPrefix += pathSeparator + pathParts[i];
     }
 
     snapshotIndex = 0;

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -199,7 +199,7 @@ module.exports.setupTest = function (primaryCamera) {
         }
     }
     
-    snapshotPrefix = pathParts[testIndex]
+    snapshotPrefix = pathParts[testsIndex];
     for (var i = testsIndex + 1; i < pathParts.length; ++i) {
         snapshotPrefix += pathSeparator + pathParts[i];
     }

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -50,7 +50,7 @@ var runOneStep = function (stepFunctor, stepIndex) {
         // Image numbers are padded to 5 digits
         // Changing this number requires changing the auto-tester C++ code!
         var NUM_DIGITS = 5;
-        var currentSnapshotName = snapshotPrefix + pad(snapshotIndex, NUM_DIGITS, '0');;
+        var currentSnapshotName = snapshotPrefix + pathSeparator + pad(snapshotIndex, NUM_DIGITS, '0');;
         usePrimaryCamera ? Window.takeSnapshot(false, false, 0.0, currentSnapshotName) : Window.takeSecondaryCameraSnapshot(currentSnapshotName);
         ++snapshotIndex;
     }
@@ -202,8 +202,7 @@ module.exports.setupTest = function (primaryCamera) {
     
     snapshotPrefix = pathParts[testsIndex];
     for (var i = testsIndex + 1; i < pathParts.length; ++i) {
-        var str = pathParts[i];
-        snapshotPrefix += pathSeparator + str;
+        snapshotPrefix += pathSeparator + pathParts[i];
     }
 
     snapshotIndex = 0;


### PR DESCRIPTION
The `Use Primary Camera` flag was set but never reset.  This caused the wrong camera to be used if the primary was previously selected.