### PR TITLE
Use PNG, and start in Desktop mode.

### DIFF
--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -76,7 +76,7 @@ var runOneStep = function (stepFunctor, stepIndex) {
         // Image numbers are padded to 5 digits
         // Changing this number requires changing the auto-tester C++ code!
         var NUM_DIGITS = 5;
-        var currentSnapshotName = snapshotPrefix + pad(snapshotIndex, NUM_DIGITS, '0');;
+        var currentSnapshotName = snapshotPrefix + pad(snapshotIndex, NUM_DIGITS, '0') + ".png";
 
         currentTestCase.usePrimaryCamera 
             ? Window.takeSnapshot(isManualMode(), false, 0.0, currentSnapshotName) 
@@ -246,6 +246,11 @@ setUpTest = function(testCase) {
     // Set callback for changes in download status.  This is used so we don't advance steps when data is downloading
     AccountServices.downloadInfoChanged.connect(onDownloadInfoChanged);
     AccountServices.updateDownloadInfo();
+
+    // Enforce Desktop display (unless manual mode)
+    if (!isManualMode()) {
+        Menu.setIsOptionChecked("Desktop", true);
+    }
 }
 
 tearDownTest = function() {


### PR DESCRIPTION
# Description
1.  Interface snapshots are now stored in PNG format, if the filename suffix is .PNG - this is now supported
2.  There are cases when Interface starts up in VR mode; this will break the recursive tests.  `autoTester.js` now starts in Desktop mode (by setting the menu option).