### PR TITLE
Added command line options to Batch File.

### DIFF
--- a/batch files/DailyTests.bat
+++ b/batch files/DailyTests.bat
@@ -2,7 +2,7 @@
 
 REM First parameter is compulsory - which GitHub branch to run from
 REM Second parameter is compulsory - installation directory for the HighFidelity executable
-REM Third parameter is compulsory - installation directory for the HighFidelity executable
+REM Third parameter is compulsory - directory for the test results (snapshots and zipped error log).
 REM Fourth parameter selects the GitHub user, default is "highfidelity" (useful for debugging)
 
 REM Exit, with message, if branch parameter is missing

--- a/batch files/DailyTests.bat
+++ b/batch files/DailyTests.bat
@@ -1,8 +1,52 @@
-ECHO OFF
-@ECHO Starting Test
+@ECHO OFF
+
+REM First parameter is compulsory - which GitHub branch to run from
+REM Second parameter is compulsory - installation directory for the HighFidelity executable
+REM Third parameter is compulsory - installation directory for the HighFidelity executable
+REM Fourth parameter selects the GitHub user, default is "highfidelity" (useful for debugging)
+
+REM Exit, with message, if branch parameter is missing
+IF NOT "%~1" == "" GOTO :BRANCH_PARAMETER_FOUND
+ECHO Missing branch parameter
+EXIT /b
+
+:BRANCH_PARAMETER_FOUND
+    
+SET BRANCH=%1
+ECHO Starting Test for %BRANCH%
+
+REM Exit, with message, if installation directory parameter is missing
+IF NOT "%~2" == "" GOTO :INSTALLATION_DIRECTORY_PARAMETER_FOUND
+ECHO Missing installation directory parameter
+EXIT /b
+
+:INSTALLATION_DIRECTORY_PARAMETER_FOUND
+    
+SET INSTALL_DIR=%2
+ECHO Will install into %INSTALL_DIR%
+
+REM Exit, with message, if test directory parameter is missing
+IF NOT "%~3" == "" GOTO :TEST_DIRECTORY_PARAMETER_FOUND
+ECHO Missing test directory parameter
+EXIT /b
+
+:TEST_DIRECTORY_PARAMETER_FOUND
+    
+SET TEST_RESULT_LOCATION=%3
+ECHO Test results will be in %TEST_RESULT_LOCATION%
+
+SET USER="highfidelity"
+IF "%~4" == "" GOTO :NO_USER_PARAMETER
+SET USER=%4
+
+:NO_USER_PARAMETER
+
+ECHO Before starting - stopping any local server that may be running
+taskkill /im assignment-client.exe /f >nul
+taskkill /im domain-server.exe /f >nul
 
 REM PowerShell can load from a URL
-@ECHO Downloading Installation files
+ECHO Downloading Installation files
 PowerShell.exe -ExecutionPolicy Bypass -Command "& '%~dpn0.ps1'"
 
 REM Verify installer was downloaded
@@ -11,26 +55,27 @@ IF NOT EXIST HighFidelity-Beta-latest-dev.exe (
     EXIT
 )
 
-REM Directory for installation
-SET INSTALL_DIR=D:\DT1
-SET TEST_RESULT_LOCATION=D:\t
-
 REM S - silent, D - directory
-REM Note that %INSTALL_DIR% will be created if needed.
 ECHO Running installer
 START /WAIT HighFidelity-Beta-latest-dev.exe /S /D=%INSTALL_DIR%
+
+ECHO Deleting all previous images
+DEL %TEST_RESULT_LOCATION%\*.png
 
 ECHO Starting local server
 start "DS" %INSTALL_DIR%\domain-server.exe
 start "AC" %INSTALL_DIR%\assignment-client.exe -n 6
- 
+
+ECHO Waiting for server to stabilize 
+ping localhost -n 7 >nul
+
 ECHO Running Interface tests
-%INSTALL_DIR%\interface.exe --url hifi://localhost/8000,8000,8000/0,0.0,0.0,1.0 --testScript https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/testRecursive.js quitWhenFinished --testResultsLocation %TEST_RESULT_LOCATION%
+START /WAIT %INSTALL_DIR%\interface.exe --url hifi://localhost/8000,8000,8000/0,0.0,0.0,1.0 --testScript https://raw.githubusercontent.com/%USER%/hifi_tests/%BRANCH%/tests/testRecursive.js quitWhenFinished --testResultsLocation %TEST_RESULT_LOCATION%
 
 ECHO Stopping local server
 taskkill /im assignment-client.exe /f >nul
 taskkill /im domain-server.exe /f >nul
 
-@ECHO Completed test, starting evaluation
-START /WAIT %AUTOTESTER_PATH%\Release\auto-tester.exe --testFolder %TEST_RESULT_LOCATION%
-@ECHO Evaluation complete
+ECHO Completed test, starting evaluation
+START /WAIT %AUTOTESTER_PATH%\Release\auto-tester.exe --testFolder %TEST_RESULT_LOCATION% --branch %BRANCH% --user %USER%
+ECHO Evaluation complete


### PR DESCRIPTION
# Description
A number of parameters have been added to the Windows batch file that runs the test suite.
The command line is now:
`DailyTests.bat <branch> <installation folder> <test folder> [<username>]`

`<branch>` is the GitHub branch.  This can be master (when testing the master branch), or RC69, RC70 and so on when testing a specific branch. NOTE: the batch file has to be edited to test test a specific branch - this is because of lack of correlation between build number and RC number.

`<installation folder>` is a local folder that High Fidelity will be installed in.

<test folder> is the folder where snapshots will be stored, and failures will be recorded.

`[<username>]` - is an optional parameter.  This refers to the GitHub user to run the tests from and defaults to _highfidelity_.  It is used for test development.