### PR TITLE
Deal properly with GitHub redirection.

### DIFF
--- a/tests/utils/branchUtils.js
+++ b/tests/utils/branchUtils.js
@@ -19,22 +19,36 @@ createAutoTester = function (executionPath) {
     // Default values
     var user = "highfidelity";;
     var branch = "master";
-    
-    // The format of the execution path is as follows (assuming the test is in the "tests' folder hierarchy)
-    // "https://raw.githubusercontent.com/<user>/<repository>/<branch>/tests/..."
+
+    // The format of the execution path is either (assuming the test is in the "tests' folder hierarchy)
+    //      "https://raw.githubusercontent.com/<user>/<repository>/<branch>/tests/..."
+    // or
+    //      "https://github.com/<user>/blob/<repository>/<branch>/tests/..."
+    //
     // If the first word is not "https" then the script is probably running from a local file
     var words = executionPath.split("/");
 
-    if (words[0] === "https:" && words.length >= 6) {
-        // Note that words[1] is null and words[2] is "raw.githubusercontent.com"
+    if (words[0] === "https:") {
+        // Note that words[1] is null
         user = words[3];
-        branch = words[5];
+
+        if (words[2] === "raw.githubusercontent.com") {
+            branch = words[5];
+        } else {
+            // The second format has the 'blob' token
+            branch = words[6];
+        }
     }
 
-    // This needs to work for both 'https://' and 'file://' URLs
     var repositoryPath = getRepositoryPath(executionPath);
+    var autoTesterPath = repositoryPath + "tests/utils/autoTester.js";
 
-    var autoTester =  Script.require(repositoryPath + "tests/utils/autoTester.js");
+    // For the second format we need to append "?raw=true" to the path
+    if (words[2] === "github.com") {
+        autoTesterPath = autoTesterPath + "?raw=true";
+    }
+
+    var autoTester =  Script.require(autoTesterPath);
     autoTester.setRepositoryInfo(repositoryPath);
 
     return autoTester;


### PR DESCRIPTION
# Description
The prefix of the path is analyzed.
If this is a redirected path then the ?raw=true suffix is appended.

In addition - the branch name position in the path depends on whether the path is redirected or not.