### PR TITLE
Fixed test failures due to PR 14286

### DIFF
--- a/tests/content/entity/zone/ambientLightInheritance/test.js
+++ b/tests/content/entity/zone/ambientLightInheritance/test.js
@@ -3,8 +3,9 @@ Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var autoTester = createAutoTester(Script.resolvePath("."));
 
 autoTester.perform("Zone - Ambient Light Inheritance", Script.resolvePath("."), "secondary", function(testType) {
-    var avatarOriginPosition = MyAvatar.position;
-
+    var avatarOriginPosition = autoTester.getOriginFrame();
+    avatarOriginPosition = Vec3.sum(avatarOriginPosition, { x: 0.0, y: 1.0, z: 0.0 });
+    
     var zoneRedPosition   = { x: avatarOriginPosition.x, y: avatarOriginPosition.y - 4.0, z: avatarOriginPosition.z - 17.5 };
     var zoneBluePosition  = { x: avatarOriginPosition.x, y: avatarOriginPosition.y - 4.0, z: avatarOriginPosition.z - 17.5 };
     var zoneGreenPosition = { x: avatarOriginPosition.x, y: avatarOriginPosition.y - 4.0, z: avatarOriginPosition.z - 17.5 };
@@ -85,11 +86,11 @@ autoTester.perform("Zone - Ambient Light Inheritance", Script.resolvePath("."), 
             lifetime: LIFETIME,
             type: "Sphere",
             name: "sphere",
-            position: Vec3.sum(MyAvatar.position, SPHERE_OFFSET),
+            position: Vec3.sum(avatarOriginPosition, SPHERE_OFFSET),
             dimensions: { x: 0.4, y: 0.4, z: 0.4 },
-            "color": {"red":255,"green":255,"blue":255},
+            color: { red:255, green: 255, blue: 255 },
             visible: true,
-            userData: JSON.stringify({ grabbableKey: { grabbable: false } })
+            userData: JSON.stringify({ grabbableKey: { grabbable: false }})
         };
         sphere = Entities.addEntity(sphereProperties);
     });

--- a/tests/utils/autoTester.js
+++ b/tests/utils/autoTester.js
@@ -17,6 +17,8 @@ var pathSeparator = ".";
 var previousCameraMode;
 var secondaryCameraHasBeenEnabled = false;
 
+var previousThrottleFPS;
+
 var downloadInProgress = false;
 var loadingContentIsStillDisplayed = false;
 
@@ -265,14 +267,21 @@ setUpTest = function(testCase) {
     fxaaWasOn = Render.getConfig("RenderMainView.Antialiasing").fxaaOnOff;
     Render.getConfig("RenderMainView.JitterCam").none();
     Render.getConfig("RenderMainView.Antialiasing").fxaaOnOff = true;
+    
+    // This is needed to enable valid tests when Interface does not have focus
+    // The problem is that models aren't rendered when there is no focus
+    previousThrottleFPS = Menu.isOptionChecked("Throttle FPS If Not Focus");
+    Menu.setIsOptionChecked("Throttle FPS If Not Focus", false)
 }
 
 tearDownTest = function() {
     // Clear the test case steps
     currentSteps = [];
 
-   // Reset camera mode
-    Camera.mode = previousCameraMode;
+   // Reset camera mode if needed
+    if (previousCameraMode) {
+        Camera.mode = previousCameraMode;
+    }
 
     if (isManualMode()) {
         // Disconnect key event
@@ -310,6 +319,9 @@ tearDownTest = function() {
         Render.getConfig("RenderMainView.JitterCam").play();
         Render.getConfig("RenderMainView.Antialiasing").fxaaOnOff = false;
     }
+    
+    // Restore as required
+    Menu.setIsOptionChecked("Throttle FPS If Not Focus", previousThrottleFPS)
 }
 
 validationCamera_setTranslation = function(position) {


### PR DESCRIPTION
# Description
Tests were failing in what seemed a random way.
Issue was that models were not being displayed if the window didn't have focus.

Disabling "Throttle FPS If Not Focus" solves the problem.  This has no negative effects on the tests.

# Testing
Run the full test suite - https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/testRecursive.js