### PR TITLE
Keep Highlighting enabled in 2ndary camera

### DIFF
--- a/tests/utils/nitpick.js
+++ b/tests/utils/nitpick.js
@@ -232,8 +232,9 @@ setUpTest = function(testCase) {
         spectatorCameraConfig.resetSizeSpectatorCamera(1920, 1080);
         spectatorCameraConfig.vFoV = 45;
         Render.getConfig("SecondaryCameraJob.ToneMapping").curve = 0;
-        Render.getConfig("SecondaryCameraJob.DrawHighlight").enabled = false;
-
+        // Not needed ?
+        //Render.getConfig("SecondaryCameraJob.DrawHighlight").enabled = false;
+       
         spectatorCameraConfig.orientation = q0;
         spectatorCameraConfig.position = p0;
     }

--- a/tests/utils/nitpick.js
+++ b/tests/utils/nitpick.js
@@ -232,8 +232,6 @@ setUpTest = function(testCase) {
         spectatorCameraConfig.resetSizeSpectatorCamera(1920, 1080);
         spectatorCameraConfig.vFoV = 45;
         Render.getConfig("SecondaryCameraJob.ToneMapping").curve = 0;
-        // Not needed ?
-        //Render.getConfig("SecondaryCameraJob.DrawHighlight").enabled = false;
        
         spectatorCameraConfig.orientation = q0;
         spectatorCameraConfig.position = p0;


### PR DESCRIPTION
this change should not affect the tests because i don't think that the command is working in master up until now (Build 9693 Dec 3 2018)
so in this pr we comment the disabling of highlight in secondary camera to actually pass the highlighting test:
IN master: (https://github.com/highfidelity/hifi_tests/tree/master/tests/engine/render/effect/highlight)
In this pr: https://github.com/highfidelity/hifi_tests/blob/2258e9e8b838fc9abbd5772b5826e067c6216b1c/tests/engine/render/effect/highlight

This problem is exposed with the hifi/pr https://github.com/highfidelity/hifi/pull/14455
Giving this failed result before this pr:
https://hifi-qa.s3.amazonaws.com/TestResults--2018-12-03_18-33-25(local)%5B2060-DESKTOP-PC%5D/TestResults.html

