### PR TITLE
20338 - corrected test to restore LOD settings on completion.

### DIFF
--- a/tests/engine/render/lod/overlay/model/test.js
+++ b/tests/engine/render/lod/overlay/model/test.js
@@ -8,6 +8,9 @@ nitpick.perform("LOD test", Script.resolvePath("."), "secondary", function(testT
     var LIFETIME = 120;
     var DIM = {x: 1.0, y: 1.2, z: 0.28};
 
+    var previousLODAdjust;
+    var previousOctreeSizeScale;
+
     MyAvatar.orientation = Quat.fromPitchYawRollDegrees(0.0, 0.0, 0.0);
     
     var pos = nitpick.getOriginFrame();
@@ -39,7 +42,10 @@ nitpick.perform("LOD test", Script.resolvePath("."), "secondary", function(testT
         isVisibleInSecondaryCamera: true
     }));
     
+    previousLODAdjust = LODManager.getAutomaticLODAdjust();
     LODManager.setAutomaticLODAdjust(false);
+
+    previousOctreeSizeScale = LODManager.getOctreeSizeScale();
     LODManager.setOctreeSizeScale(32768 * 400);
 
     nitpick.addStepSnapshot("Both models visible");
@@ -65,8 +71,8 @@ nitpick.perform("LOD test", Script.resolvePath("."), "secondary", function(testT
             Overlays.deleteOverlay(createdOverlays[i]);
         }
 
-        LODManager.setOctreeSizeScale(32768 * 400);
-        LODManager.setAutomaticLODAdjust(true);
+        LODManager.setOctreeSizeScale(previousOctreeSizeScale);
+        LODManager.setAutomaticLODAdjust(previousLODAdjust);
     });
 
     nitpick.runTest(testType);


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/20338/LOD-test-not-restoring-state
# Description
Restores LOD settings to pre-test values.
# Testing
1.  Verify that the following test passes: https://raw.githubusercontent.com/NissimHadar/hifi_tests/20338-fixLODTest/tests/engine/render/lod/overlay/model/test.js
2.  Run the full test suite on Mac: https://raw.githubusercontent.com/NissimHadar/hifi_tests/20338-fixLODTest/tests/testRecursive.js.
3.  Verify that LOD levels are not causing test failures (visible when the checkered background is not displayed in full).