### PR TITLE
20339  - ensure no entities

### DIFF
--- a/tests/engine/render/lod/overlay/model/test.js
+++ b/tests/engine/render/lod/overlay/model/test.js
@@ -8,6 +8,9 @@ nitpick.perform("LOD test", Script.resolvePath("."), "secondary", function(testT
     var LIFETIME = 120;
     var DIM = {x: 1.0, y: 1.2, z: 0.28};
 
+    var previousLODAdjust;
+    var octreeSizeScale;
+
     MyAvatar.orientation = Quat.fromPitchYawRollDegrees(0.0, 0.0, 0.0);
     
     var pos = nitpick.getOriginFrame();
@@ -39,7 +42,10 @@ nitpick.perform("LOD test", Script.resolvePath("."), "secondary", function(testT
         isVisibleInSecondaryCamera: true
     }));
     
+    previousLODAdjust = LODManager.getAutomaticLODAdjust();
     LODManager.setAutomaticLODAdjust(false);
+
+    octreeSizeScale = LODManager.getOctreeSizeScale();
     LODManager.setOctreeSizeScale(32768 * 400);
 
     nitpick.addStepSnapshot("Both models visible");
@@ -65,8 +71,8 @@ nitpick.perform("LOD test", Script.resolvePath("."), "secondary", function(testT
             Overlays.deleteOverlay(createdOverlays[i]);
         }
 
-        LODManager.setOctreeSizeScale(32768 * 400);
-        LODManager.setAutomaticLODAdjust(true);
+        LODManager.setOctreeSizeScale(octreeSizeScale);
+        LODManager.setAutomaticLODAdjust(previousLODAdjust);
     });
 
     nitpick.runTest(testType);

--- a/tests/utils/nitpick.js
+++ b/tests/utils/nitpick.js
@@ -281,7 +281,16 @@ setUpTest = function(testCase) {
     // This is needed to enable valid tests when Interface does not have focus
     // The problem is that models aren't rendered when there is no focus
     previousThrottleFPS = Menu.isOptionChecked("Throttle FPS If Not Focus");
-    Menu.setIsOptionChecked("Throttle FPS If Not Focus", false)
+    Menu.setIsOptionChecked("Throttle FPS If Not Focus", false);
+	
+	// Remove all entities in the test neighbourhood, unless in manual mode
+    if (!isManualMode()) {
+        const TEST_RADIUS = 1000;
+        var entitiesToDelete = Entities.findEntities(originFrame, TEST_RADIUS);
+        for (var i = 0; i < entitiesToDelete.length; ++i) {
+            Entities.deleteEntity(entitiesToDelete[i]);
+        }
+    }
 }
 
 tearDownTest = function() {


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/20339/Ensure-test-environment-is-clear-of-entities
# Description
During automated testing, entities may be left over from previous tests.  These can cause tests to fail, especially if these entities include a zone.

To solve this - all entities within a 1000 metre radius are deleted, when running in an automatic mode.
# Testing
1.  Run Interface and go to localhost.
2.  Move to a remote region (such as 9999,9999,9999)
3.  Create some entities at that location - (i.e. cube, sphere and text)
4.  Run the following test: https://raw.githubusercontent.com/NissimHadar/hifi_tests/20339-ensureNoEntities/tests/engine/render/lod/overlay/model/test.js
5.  Verify that the added entities  have NOT been deleted.
6.  Run the following test: https://raw.githubusercontent.com/NissimHadar/hifi_tests/20339-ensureNoEntities/tests/engine/render/lod/overlay/model/testAuto.js
7.  Verify the added entities have been deleted.  There should be no entities nearby after the test has been completed.
8.  Re-add some entities.
9.  Run the following test: https://raw.githubusercontent.com/NissimHadar/hifi_tests/20339-ensureNoEntities/tests/engine/render/lod/overlay/testRecursive.js
10.  Verify the added entities have been deleted.  There should be no entities nearby after the test has been completed.