### PR TITLE
Case 20531 - Increase delay from 4 to 8 steps.

### DIFF
--- a/tests/content/entity/model/modelReaders/fbxReader/still_life/test.js
+++ b/tests/content/entity/model/modelReaders/fbxReader/still_life/test.js
@@ -47,8 +47,8 @@ nitpick.perform("Read still life FBX model", Script.resolvePath("."), "secondary
         userData: JSON.stringify({ grabbableKey: { grabbable: false } })
     }));
 
-    nitpick.addDelay(4);
-    nitpick.addStepSnapshot("Still life OBJ model");
+    nitpick.addDelay(8);
+    nitpick.addStepSnapshot("Still life FBX model");
 
     nitpick.addStep("Clean up after test", function () {
         for (var i = 0; i < createdEntities.length; i++) {

--- a/tests/content/entity/model/modelReaders/fbxReader/still_life/test.md
+++ b/tests/content/entity/model/modelReaders/fbxReader/still_life/test.md
@@ -8,7 +8,7 @@
 Press 'n' key to advance step by step
 
 ### Step 1
-- Still life OBJ model
+- Still life FBX model
 - ![](./ExpectedImage_00000.png)
 ### Step 2
 - Clean up after test


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/20531/Fix-tests-content-entity-model-modelReaders-fbxReader-still_life-test-js
# Description
Increases the delay between loading and testing.
# Testing
1.  Run https://raw.githubusercontent.com/NissimHadar/hifi_tests/20531-addDelayToTest/tests/content/entity/model/modelReaders/fbxReader/still_life/testAuto.js and verify that test passes.
2.  Run https://raw.githubusercontent.com/NissimHadar/hifi_tests/20531-addDelayToTest/tests/content/entity/model/modelReaders/fbxReader/testRecursive.js and verify that both tests pass.