### PR TITLE
Case 20681 - removed `owningAvatarID` from protocol tests (not sent over wire).

### DIFF
--- a/tests/protocol/common.js
+++ b/tests/protocol/common.js
@@ -94,7 +94,6 @@ setCommonEntityProperties = function() {
 
     entityProperties.name = "Name of entity";
     entityProperties.clientOnly = false;
-    entityProperties.owningAvatarID = "{87654321-1234-6666-4444-123412349876}";
     entityProperties.lifetime = 278;  
     entityProperties.locked = true;
     entityProperties.visible = false;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20681/All-entity-protocol-tests-fail-in-RC78
# Description
The `owningAvatarID` property is no longer passed to the server.
# Testing
Run the following test:
https://raw.githubusercontent.com/NissimHadar/hifi_tests/20681-updateProtocolTests/tests/protocol/testRecursive.js