### PR TITLE
(case 22368) Add manual test for snapshots

### DIFF
--- a/tests/engine/ui/snapshot/story.md
+++ b/tests/engine/ui/snapshot/story.md
@@ -1,0 +1,30 @@
+# Test snapshot with no snap directory set
+## Run this script URL: [Manual](./testStory.js?raw=true)
+
+## Preconditions
+- In a domain with moving or animated objects (required to test the snapshot GIF functionality)
+- You have created an empty folder on your computer at a location of your choice. Designate this folder as your chosen snapshot directory, to use for the duration of this test.
+
+## Step 1 - Primary Camera Snapshot
+- Press 'n' on keyboard to advance the test to this step
+- Interface will prompt for a snapshot location. Verify you can continue to move your avatar in the domain with the directory prompt still open.
+- Provide your chosen snapshot directory.
+- Verify the directory now contains a new screenshot of Interface
+
+## Step 2 - Primary Camera Snapshot and GIF
+- Face your avatar toward another direction, facing a moving or animated environment, then press 'n' on keyboard to advance the test to this step
+- Interface will prompt for a snapshot location. Verify you can continue to move your avatar in the domain with the directory prompt still open.
+- Provide your chosen snapshot directory. After confirming your directory choice, wait until the notification message "processing GIF snapshot" appears, then wait a few more seconds. Verify the directory now contains a new screenshot of Interface, as well as an animated GIF of Interface.
+
+## Step 3 - Secondary Camera Snapshot
+- Face your avatar toward another direction, then press 'n' on keyboard to advance the test to this step
+- Interface will prompt for a snapshot location. Verify you can continue to move your avatar in the domain with the directory prompt still open.
+- Provide your chosen snapshot directory. After confirming your directory choice, verify the directory now contains a new picture from your avatar's perspective.
+
+## Step 4 - Secondary Camera 360 Snapshot
+- Press 'n' on keyboard to advance the test to this step
+- After a delay, Interface will prompt for a snapshot location. Verify you can continue to move your avatar in the domain with the directory prompt still open.
+- Provide your chosen snapshot directory. After confirming your directory choice, verify the directory now contains a new panorama picture of your environment.
+
+## Step 5
+- Press 'n' on keyboard to conclude test

--- a/tests/engine/ui/snapshot/testStory.js
+++ b/tests/engine/ui/snapshot/testStory.js
@@ -1,0 +1,58 @@
+if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/utils/branchUtils.js";
+Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
+var nitpick = createNitpick(Script.resolvePath("."));
+Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
+
+nitpick.perform("Test snapshot with no snap directory set", Script.resolvePath("."), "secondary", function(testType) {
+    
+    var oldSnapshotsLocation;
+    
+    function cleanup() {
+        if (oldSnapshotsLocation != undefined) {
+            Snapshot.setSnapshotsLocation(oldSnapshotsLocation);
+            oldSnapshotsLocation = undefined;
+        }
+    }
+    
+    Script.scriptEnding.connect(cleanup);
+    
+    function clearSnapshotsLocation() {
+        if (oldSnapshotsLocation == undefined) {
+            oldSnapshotsLocation = Snapshot.getSnapshotsLocation();
+        }
+        Snapshot.setSnapshotsLocation("");
+    }
+    
+    nitpick.addStep("Primary Camera Snapshot", function () {
+        clearSnapshotsLocation();
+        Window.takeSnapshot();
+    });
+    
+    nitpick.addStep("Primary Camera Snapshot and GIF", function () {
+        clearSnapshotsLocation();
+        Window.takeSnapshot(false, true);
+    });
+    
+    nitpick.addStep("Secondary Camera Snapshot", function () {
+        clearSnapshotsLocation();
+        var secondaryCamera = Render.getConfig("SecondaryCamera");
+        secondaryCamera.position = Camera.position;
+        secondaryCamera.orientation = Camera.orientation;
+        
+        Window.takeSecondaryCameraSnapshot();
+    });
+    
+    nitpick.addStep("Secondary Camera 360 Snapshot", function () {
+        clearSnapshotsLocation();
+        var secondaryCamera = Render.getConfig("SecondaryCamera");
+        secondaryCamera.position = Camera.position;
+        secondaryCamera.orientation = Camera.orientation;
+        Window.takeSecondaryCamera360Snapshot(MyAvatar.position);
+    });
+    
+    nitpick.addStep("Clean up after test", function () {
+        cleanup();
+    });
+    
+    var result = nitpick.runTest(testType);
+});

--- a/tests/engine/ui/snapshot/testStory.js
+++ b/tests/engine/ui/snapshot/testStory.js
@@ -30,7 +30,7 @@ nitpick.perform("Test snapshot with no snap directory set", Script.resolvePath("
     
     nitpick.addStep("Primary Camera Snapshot and GIF", function () {
         clearSnapshotsLocation();
-        Window.takeSnapshot(false, true);
+        Window.takeSnapshot(true, true);
     });
     
     nitpick.addStep("Secondary Camera Snapshot", function () {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22368/Crash-deadlock-when-taking-snapshot-from-hifi-test-with-no-snap-directory-set
https://highfidelity.atlassian.net/browse/BUGZ-10
Associated Interface PR: https://github.com/highfidelity/hifi/pull/15502

This PR adds a manual test checking each snapshot type, clearing the snapshot directory each time to check that the snapshot prompt also works.

Attempting to use this test on current master will deadlock Interface. It should be used with the associated Interface PR.