### PR TITLE
Changed secondary camera's tone mapping to SRGB

### DIFF
--- a/tests/utils/nitpick.js
+++ b/tests/utils/nitpick.js
@@ -276,7 +276,7 @@ setUpTest = function(testCase) {
 
         spectatorCameraConfig.resetSizeSpectatorCamera(1920, 1080);
         spectatorCameraConfig.vFoV = 45;
-        Render.getConfig("SecondaryCameraJob.ToneMapping").curve = 0;
+        Render.getConfig("SecondaryCameraJob.ToneMapping").curve = 1;
        
         spectatorCameraConfig.orientation = q0;
         spectatorCameraConfig.position = p0;

--- a/tests/utils/nitpick.js
+++ b/tests/utils/nitpick.js
@@ -276,7 +276,6 @@ setUpTest = function(testCase) {
 
         spectatorCameraConfig.resetSizeSpectatorCamera(1920, 1080);
         spectatorCameraConfig.vFoV = 45;
-        Render.getConfig("SecondaryCameraJob.ToneMapping").curve = 1;
        
         spectatorCameraConfig.orientation = q0;
         spectatorCameraConfig.position = p0;


### PR DESCRIPTION
Nitpick used to compensate for the fact that that secondary camera was too light by setting its curve manually to RGB. After PR #15862 the secondary camera image is correct, so its curve can be set back to SRGB here.