### PR TITLE
(DEV-359) Nitpick shouldRun prototype + disable shadow tests on low tier

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -151,7 +151,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     var nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Test Description", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test Description", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // set up zones, objects and other entities 
     
     // create steps

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,17 +143,18 @@ Each test is in a separate folder, which should contain the following files:
 4. Expected_Image_xxxx - these are created by running the script and then using `nitpick`.
 5. In addition - `nitpick` is used to create recursive scripts.  These are all named **testRecursive.js** and will run every applicable test (i.e., those named *test.js*) in all subfolders below this script.  This allows running **ALL** the tests, by running the *testRecursive.js* script located in the **tests** root folder.
 # Test Script Structure
-A test script has the following structure:  
+A test script has the following structure:
 ```
-if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/utils/branchUtils.js";
+if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
+    PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/utils/branchUtils.js";
+    Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
+    var nitpick = createNitpick(Script.resolvePath("."));
+}
 
-Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
-
-var nitpick = createNitpick(Script.resolvePath("."));
-
-nitpick.perform("Test Description", Script.resolvePath("."), "secondary", function(testType) {
-
-   <list of steps>
+nitpick.perform("Test Description", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+    // set up zones, objects and other entities 
+    
+    // create steps
   
    nitpick.runTest(testType);
 });

--- a/tests/content/entity/grid/alpha/testStory.js
+++ b/tests/content/entity/grid/alpha/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity alpha", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Grid Entity alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/grid/alpha/testStory.js
+++ b/tests/content/entity/grid/alpha/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Grid Entity alpha", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/grid/color/testStory.js
+++ b/tests/content/entity/grid/color/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Grid Entity color", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/grid/color/testStory.js
+++ b/tests/content/entity/grid/color/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity color", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Grid Entity color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/grid/followCamera/testStory.js
+++ b/tests/content/entity/grid/followCamera/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity followCamera", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Grid Entity followCamera", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/grid/followCamera/testStory.js
+++ b/tests/content/entity/grid/followCamera/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity followCamera", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Grid Entity followCamera", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/grid/gridEvery/testStory.js
+++ b/tests/content/entity/grid/gridEvery/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity minorGridEvery/majorGridEvery", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Grid Entity minorGridEvery/majorGridEvery", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/grid/gridEvery/testStory.js
+++ b/tests/content/entity/grid/gridEvery/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Grid Entity minorGridEvery/majorGridEvery", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Grid Entity minorGridEvery/majorGridEvery", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/alpha/test.js
+++ b/tests/content/entity/image/alpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Image Entity alpha", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/alpha/test.js
+++ b/tests/content/entity/image/alpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity alpha", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Image Entity alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/billboardMode/test.js
+++ b/tests/content/entity/image/billboardMode/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity billboardMode", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Image Entity billboardMode", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/billboardMode/test.js
+++ b/tests/content/entity/image/billboardMode/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity billboardMode", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Image Entity billboardMode", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/color/test.js
+++ b/tests/content/entity/image/color/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Image Entity color", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/color/test.js
+++ b/tests/content/entity/image/color/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity color", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Image Entity color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/emissive/test.js
+++ b/tests/content/entity/image/emissive/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity emissive", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Image Entity emissive", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/emissive/test.js
+++ b/tests/content/entity/image/emissive/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity emissive", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Image Entity emissive", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/keepAspectRatio/test.js
+++ b/tests/content/entity/image/keepAspectRatio/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity keepAspectRatio", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Image Entity keepAspectRatio", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/keepAspectRatio/test.js
+++ b/tests/content/entity/image/keepAspectRatio/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity keepAspectRatio", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Image Entity keepAspectRatio", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/subImage/test.js
+++ b/tests/content/entity/image/subImage/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity subImage", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Image Entity subImage", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/image/subImage/test.js
+++ b/tests/content/entity/image/subImage/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Image Entity subImage", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Image Entity subImage", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/light/point/create/test.js
+++ b/tests/content/entity/light/point/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Point light", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Point light", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/content/entity/light/point/create/test.js
+++ b/tests/content/entity/light/point/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Point light", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Point light", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/content/entity/light/spot/create/test.js
+++ b/tests/content/entity/light/spot/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Spot light", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Spot light", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/content/entity/light/spot/create/test.js
+++ b/tests/content/entity/light/spot/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Spot light", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Spot light", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/content/entity/material/apply/avatars/test.js
+++ b/tests/content/entity/material/apply/avatars/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Avatars", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Apply Material Entities to Avatars", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/avatars/test.js
+++ b/tests/content/entity/material/apply/avatars/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Avatars", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Apply Material Entities to Avatars", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/entities/model/test.js
+++ b/tests/content/entity/material/apply/entities/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Model Entities", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Apply Material Entities to Model Entities", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/entities/model/test.js
+++ b/tests/content/entity/material/apply/entities/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Model Entities", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Apply Material Entities to Model Entities", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/entities/shape/test.js
+++ b/tests/content/entity/material/apply/entities/shape/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Shape Entities", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Apply Material Entities to Shape Entities", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/entities/shape/test.js
+++ b/tests/content/entity/material/apply/entities/shape/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Shape Entities", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Apply Material Entities to Shape Entities", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/overlays/model/test.js
+++ b/tests/content/entity/material/apply/overlays/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Model Overlays", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Apply Material Entities to Model Overlays", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/overlays/model/test.js
+++ b/tests/content/entity/material/apply/overlays/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Apply Material Entities to Model Overlays", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Apply Material Entities to Model Overlays", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/targeting/test.js
+++ b/tests/content/entity/material/apply/targeting/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material targeting", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Material targeting", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/apply/targeting/test.js
+++ b/tests/content/entity/material/apply/targeting/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material targeting", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Material targeting", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/create/test.js
+++ b/tests/content/entity/material/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material Entities", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Material Entities", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/material/create/test.js
+++ b/tests/content/entity/material/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material Entities", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Material Entities", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/material/fallthrough/test.js
+++ b/tests/content/entity/material/fallthrough/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material fallthrough", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Material fallthrough", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/material/fallthrough/test.js
+++ b/tests/content/entity/material/fallthrough/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material fallthrough", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Material fallthrough", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
     // Add the test Cases

--- a/tests/content/entity/model/modelBaking/normal_texture/test.js
+++ b/tests/content/entity/model/modelBaking/normal_texture/test.js
@@ -5,7 +5,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 }
 Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
-nitpick.perform("Read FBX model with normal texture", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read FBX model with normal texture", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = MyAvatar.position;

--- a/tests/content/entity/model/modelBaking/normal_texture/test.js
+++ b/tests/content/entity/model/modelBaking/normal_texture/test.js
@@ -5,7 +5,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 }
 Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
-nitpick.perform("Read FBX model with normal texture", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read FBX model with normal texture", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = MyAvatar.position;

--- a/tests/content/entity/model/modelReaders/fbxReader/simple/test.js
+++ b/tests/content/entity/model/modelReaders/fbxReader/simple/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read FBX model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read FBX model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/fbxReader/simple/test.js
+++ b/tests/content/entity/model/modelReaders/fbxReader/simple/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read FBX model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read FBX model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/fbxReader/still_life/testStory.js
+++ b/tests/content/entity/model/modelReaders/fbxReader/still_life/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Read still life FBX model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read still life FBX model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
 

--- a/tests/content/entity/model/modelReaders/fbxReader/still_life/testStory.js
+++ b/tests/content/entity/model/modelReaders/fbxReader/still_life/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Read still life FBX model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read still life FBX model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
 

--- a/tests/content/entity/model/modelReaders/fbxReader/uv_scale/test.js
+++ b/tests/content/entity/model/modelReaders/fbxReader/uv_scale/test.js
@@ -5,7 +5,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 }
 Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
-nitpick.perform("Read FBX models with UV scale properties", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read FBX models with UV scale properties", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = MyAvatar.position;

--- a/tests/content/entity/model/modelReaders/fbxReader/uv_scale/test.js
+++ b/tests/content/entity/model/modelReaders/fbxReader/uv_scale/test.js
@@ -5,7 +5,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 }
 Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
-nitpick.perform("Read FBX models with UV scale properties", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read FBX models with UV scale properties", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = MyAvatar.position;

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/alphaBlend/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/alphaBlend/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/alphaBlend/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/alphaBlend/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/avocado/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/avocado/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/avocado/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/avocado/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boomBox/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boomBox/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boomBox/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boomBox/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/box/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/box/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxNPOT/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxNPOT/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxNPOT/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxNPOT/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxTexture/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxTexture/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxTexture/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/boxTexture/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/brainstem/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/brainstem/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/brainstem/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/brainstem/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/buggy/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/buggy/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/buggy/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/buggy/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/city/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/city/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/city/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/city/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/damagedHelmet/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/damagedHelmet/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/damagedHelmet/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/damagedHelmet/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/duck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/duck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/duck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/duck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/engine/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/engine/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/engine/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/engine/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/fish/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/fish/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/fish/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/fish/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/lantern/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/lantern/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/lantern/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/lantern/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/metalRoughSpheres/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/metalRoughSpheres/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/metalRoughSpheres/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/metalRoughSpheres/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/milkTruck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/milkTruck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/milkTruck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/milkTruck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/monster/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/monster/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/monster/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/monster/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangent/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangent/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangentMirror/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangentMirror/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangentMirror/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/normalTangentMirror/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/oldCamera/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/oldCamera/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/oldCamera/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/oldCamera/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/orientation/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/orientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/orientation/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/orientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedFigure/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedFigure/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedFigure/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedFigure/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedSimple/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedSimple/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedSimple/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/riggedSimple/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/specVsMetal/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/specVsMetal/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/specVsMetal/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/specVsMetal/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/textureCoordinate/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/textureCoordinate/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/textureCoordinate/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/textureCoordinate/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/vertexColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/vertexColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/vertexColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/vertexColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/waterBottle/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/waterBottle/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/waterBottle/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/glbTestSuite/waterBottle/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/alphaBlend/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/alphaBlend/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/alphaBlend/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/alphaBlend/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/avocado/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/avocado/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/avocado/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/avocado/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boomBox/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boomBox/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boomBox/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boomBox/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/box/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/box/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxNPOT/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxNPOT/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxNPOT/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxNPOT/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxTexture/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxTexture/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxTexture/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boxTexture/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/brainstem/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/brainstem/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/brainstem/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/brainstem/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/buggy/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/buggy/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/buggy/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/buggy/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/city/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/city/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/city/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/city/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/damagedHelmet/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/damagedHelmet/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/damagedHelmet/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/damagedHelmet/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/duck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/duck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/duck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/duck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/box/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/box/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/boxTexture/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/boxTexture/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/boxTexture/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/boxTexture/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/brainstem/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/brainstem/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/brainstem/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/brainstem/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/buggy/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/buggy/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/buggy/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/buggy/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/city/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/city/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/city/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/city/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/duck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/duck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/duck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/duck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/engine/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/engine/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/engine/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/engine/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/metalRoughSpheres/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/metalRoughSpheres/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/metalRoughSpheres/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/metalRoughSpheres/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/monster/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/monster/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/monster/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/monster/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/orientation/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/orientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/orientation/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/orientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/riggedFigure/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/riggedFigure/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/riggedFigure/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/riggedFigure/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/vertexColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/vertexColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/vertexColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/embedded/vertexColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/engine/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/engine/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/engine/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/engine/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/fish/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/fish/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/fish/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/fish/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/lantern/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/lantern/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/lantern/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/lantern/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/metalRoughSpheres/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/metalRoughSpheres/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/metalRoughSpheres/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/metalRoughSpheres/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/milkTruck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/milkTruck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/milkTruck/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/milkTruck/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/monster/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/monster/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/monster/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/monster/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangent/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangent/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangentMirror/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangentMirror/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangentMirror/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/normalTangentMirror/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/oldCamera/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/oldCamera/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/oldCamera/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/oldCamera/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/orientation/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/orientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/orientation/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/orientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedFigure/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedFigure/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedFigure/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedFigure/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedSimple/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedSimple/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedSimple/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/riggedSimple/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/scifiHelmet/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/scifiHelmet/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/scifiHelmet/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/scifiHelmet/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/simpleSparse/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/simpleSparse/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/simpleSparse/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/simpleSparse/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/specVsMetal/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/specVsMetal/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/specVsMetal/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/specVsMetal/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/sponza/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/sponza/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/sponza/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/sponza/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/suzanne/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/suzanne/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/suzanne/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/suzanne/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/textureCoordinate/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/textureCoordinate/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/textureCoordinate/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/textureCoordinate/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/vertexColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/vertexColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/vertexColor/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/vertexColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/waterBottle/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/waterBottle/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/waterBottle/test.js
+++ b/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/waterBottle/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read GLTF model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
     var position = nitpick.getOriginFrame();

--- a/tests/content/entity/model/modelReaders/objReader/still_life/testStory.js
+++ b/tests/content/entity/model/modelReaders/objReader/still_life/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Read still life OBJ model", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read still life OBJ model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
 

--- a/tests/content/entity/model/modelReaders/objReader/still_life/testStory.js
+++ b/tests/content/entity/model/modelReaders/objReader/still_life/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Read still life OBJ model", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read still life OBJ model", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
 

--- a/tests/content/entity/model/modelReaders/objReader/transparent/test.js
+++ b/tests/content/entity/model/modelReaders/objReader/transparent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read OBJ model with transparency", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Read OBJ model with transparency", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
 

--- a/tests/content/entity/model/modelReaders/objReader/transparent/test.js
+++ b/tests/content/entity/model/modelReaders/objReader/transparent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Read OBJ model with transparency", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Read OBJ model with transparency", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var assetsRootPath = nitpick.getAssetsRootPath();
     var LIFETIME = 60.0;
 

--- a/tests/content/entity/model/renderLayer/front/test.js
+++ b/tests/content/entity/model/renderLayer/front/test.js
@@ -7,7 +7,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 // Create the material test model matrix
 // Based on: https://raw.githubusercontent.com/highfidelity/hifi_tests/master/assets/models/material_matrix_models/material_matrix.js
 
-nitpick.perform("Model Entity renderLayer front", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Model Entity renderLayer front", Script.resolvePath("."), "secondary", undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/content/entity/model/renderLayer/front/test.js
+++ b/tests/content/entity/model/renderLayer/front/test.js
@@ -7,7 +7,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 // Create the material test model matrix
 // Based on: https://raw.githubusercontent.com/highfidelity/hifi_tests/master/assets/models/material_matrix_models/material_matrix.js
 
-nitpick.perform("Model Entity renderLayer front", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Model Entity renderLayer front", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/content/entity/model/renderLayer/hud/test.js
+++ b/tests/content/entity/model/renderLayer/hud/test.js
@@ -7,7 +7,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 // Create the material test model matrix
 // Based on: https://raw.githubusercontent.com/highfidelity/hifi_tests/master/assets/models/material_matrix_models/material_matrix.js
 
-nitpick.perform("Model Entity renderLayer hud", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Model Entity renderLayer hud", Script.resolvePath("."), "secondary", undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/content/entity/model/renderLayer/hud/test.js
+++ b/tests/content/entity/model/renderLayer/hud/test.js
@@ -7,7 +7,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 // Create the material test model matrix
 // Based on: https://raw.githubusercontent.com/highfidelity/hifi_tests/master/assets/models/material_matrix_models/material_matrix.js
 
-nitpick.perform("Model Entity renderLayer hud", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Model Entity renderLayer hud", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/content/entity/parenting/test.js
+++ b/tests/content/entity/parenting/test.js
@@ -3,7 +3,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
     nitpick = createNitpick(Script.resolvePath('.'));
 
-nitpick.perform("Entity parenting", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Entity parenting", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 120;
     var zone;
     var parent;

--- a/tests/content/entity/parenting/test.js
+++ b/tests/content/entity/parenting/test.js
@@ -3,7 +3,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
     nitpick = createNitpick(Script.resolvePath('.'));
 
-nitpick.perform('Entity parenting', Script.resolvePath('.'), 'secondary', function(testType) {
+nitpick.perform("Entity parenting", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 120;
     var zone;
     var parent;

--- a/tests/content/entity/particleEffect/alpha/testStory.js
+++ b/tests/content/entity/particleEffect/alpha/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("ParticleEffect alpha", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/alpha/testStory.js
+++ b/tests/content/entity/particleEffect/alpha/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect alpha", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("ParticleEffect alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/color/testStory.js
+++ b/tests/content/entity/particleEffect/color/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("ParticleEffect color", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/color/testStory.js
+++ b/tests/content/entity/particleEffect/color/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect color", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("ParticleEffect color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/emitterShouldTrail/testStory.js
+++ b/tests/content/entity/particleEffect/emitterShouldTrail/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect emitterShouldTrail", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("ParticleEffect emitterShouldTrail", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/emitterShouldTrail/testStory.js
+++ b/tests/content/entity/particleEffect/emitterShouldTrail/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect emitterShouldTrail", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("ParticleEffect emitterShouldTrail", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/isEmitting/testStory.js
+++ b/tests/content/entity/particleEffect/isEmitting/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect isEmitting", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("ParticleEffect isEmitting", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/isEmitting/testStory.js
+++ b/tests/content/entity/particleEffect/isEmitting/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect isEmitting", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("ParticleEffect isEmitting", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/radius/testStory.js
+++ b/tests/content/entity/particleEffect/radius/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect radius", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("ParticleEffect radius", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/radius/testStory.js
+++ b/tests/content/entity/particleEffect/radius/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect radius", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("ParticleEffect radius", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/spin/testStory.js
+++ b/tests/content/entity/particleEffect/spin/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect spin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("ParticleEffect spin", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/particleEffect/spin/testStory.js
+++ b/tests/content/entity/particleEffect/spin/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("ParticleEffect spin", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("ParticleEffect spin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 200;
 
     var createdEntities = [];

--- a/tests/content/entity/polyline/color/test.js
+++ b/tests/content/entity/polyline/color/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity color", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/color/test.js
+++ b/tests/content/entity/polyline/color/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity color", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/faceCamera/test.js
+++ b/tests/content/entity/polyline/faceCamera/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity faceCamera", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity faceCamera", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/faceCamera/test.js
+++ b/tests/content/entity/polyline/faceCamera/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity faceCamera", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity faceCamera", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/glow/test.js
+++ b/tests/content/entity/polyline/glow/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity glow", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity glow", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/glow/test.js
+++ b/tests/content/entity/polyline/glow/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity glow", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity glow", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/isUVModeStretch/test.js
+++ b/tests/content/entity/polyline/isUVModeStretch/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity isUVModeStretch", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity isUVModeStretch", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/isUVModeStretch/test.js
+++ b/tests/content/entity/polyline/isUVModeStretch/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity isUVModeStretch", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity isUVModeStretch", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/linePoints/test.js
+++ b/tests/content/entity/polyline/linePoints/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity linePoints", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity linePoints", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/linePoints/test.js
+++ b/tests/content/entity/polyline/linePoints/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity linePoints", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity linePoints", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/normals/test.js
+++ b/tests/content/entity/polyline/normals/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity normals", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity normals", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/normals/test.js
+++ b/tests/content/entity/polyline/normals/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity normals", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity normals", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/strokeColors/test.js
+++ b/tests/content/entity/polyline/strokeColors/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity strokeColors", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity strokeColors", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/strokeColors/test.js
+++ b/tests/content/entity/polyline/strokeColors/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity strokeColors", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity strokeColors", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/textures/test.js
+++ b/tests/content/entity/polyline/textures/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity textures", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyline Entity textures", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/polyline/textures/test.js
+++ b/tests/content/entity/polyline/textures/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyline Entity textures", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyline Entity textures", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/procedural/iGlobalTime/testStory.js
+++ b/tests/content/entity/procedural/iGlobalTime/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Procedural iGlobalTime", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Procedural iGlobalTime", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var entityIds = [];
 
     var LIFETIME = 60; // 1 min

--- a/tests/content/entity/procedural/iGlobalTime/testStory.js
+++ b/tests/content/entity/procedural/iGlobalTime/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Procedural iGlobalTime", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Procedural iGlobalTime", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var entityIds = [];
 
     var LIFETIME = 60; // 1 min

--- a/tests/content/entity/procedural/shapeUniforms/test.js
+++ b/tests/content/entity/procedural/shapeUniforms/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Procedural create", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Procedural create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var entityIds = [];
 
     var LIFETIME = 60; // 1 min

--- a/tests/content/entity/procedural/shapeUniforms/test.js
+++ b/tests/content/entity/procedural/shapeUniforms/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Procedural create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Procedural create", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var entityIds = [];
 
     var LIFETIME = 60; // 1 min

--- a/tests/content/entity/shape/create/test.js
+++ b/tests/content/entity/shape/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shape create", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Shape create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var entityIds = [];
 
     var LIFETIME = 60; // 1 min

--- a/tests/content/entity/shape/create/test.js
+++ b/tests/content/entity/shape/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shape create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Shape create", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var entityIds = [];
 
     var LIFETIME = 60; // 1 min

--- a/tests/content/entity/shape/renderLayer/alpha/test.js
+++ b/tests/content/entity/shape/renderLayer/alpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Overlays with alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Overlays with alpha", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var createdOverlays = [];
     var createdEntities = [];
 

--- a/tests/content/entity/shape/renderLayer/alpha/test.js
+++ b/tests/content/entity/shape/renderLayer/alpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Overlays with alpha", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Overlays with alpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var createdOverlays = [];
     var createdEntities = [];
 

--- a/tests/content/entity/shape/renderLayer/front/test.js
+++ b/tests/content/entity/shape/renderLayer/front/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shape Entity renderLayer front", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Shape Entity renderLayer front", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/content/entity/shape/renderLayer/front/test.js
+++ b/tests/content/entity/shape/renderLayer/front/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shape Entity renderLayer front", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Shape Entity renderLayer front", Script.resolvePath("."), "secondary", undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/content/entity/stage/test.js
+++ b/tests/content/entity/stage/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Test Stage", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test Stage", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/stage/test.js
+++ b/tests/content/entity/stage/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Test Stage", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test Stage", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/backgroundAlpha/test.js
+++ b/tests/content/entity/text/backgroundAlpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity backgroundAlpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity backgroundAlpha", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/backgroundAlpha/test.js
+++ b/tests/content/entity/text/backgroundAlpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity backgroundAlpha", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity backgroundAlpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/backgroundColor/test.js
+++ b/tests/content/entity/text/backgroundColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity backgroundColor", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity backgroundColor", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/backgroundColor/test.js
+++ b/tests/content/entity/text/backgroundColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity backgroundColor", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity backgroundColor", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/billboardMode/test.js
+++ b/tests/content/entity/text/billboardMode/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity billboardMode", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity billboardMode", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/billboardMode/test.js
+++ b/tests/content/entity/text/billboardMode/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity billboardMode", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity billboardMode", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/bottomMargin/test.js
+++ b/tests/content/entity/text/bottomMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity bottomMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity bottomMargin", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/bottomMargin/test.js
+++ b/tests/content/entity/text/bottomMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity bottomMargin", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity bottomMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/leftMargin/test.js
+++ b/tests/content/entity/text/leftMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity leftMargin", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity leftMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/leftMargin/test.js
+++ b/tests/content/entity/text/leftMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity leftMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity leftMargin", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/lineHeight/test.js
+++ b/tests/content/entity/text/lineHeight/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity lineHeight", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity lineHeight", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/lineHeight/test.js
+++ b/tests/content/entity/text/lineHeight/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity lineHeight", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity lineHeight", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/rightMargin/test.js
+++ b/tests/content/entity/text/rightMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity rightMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity rightMargin", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/rightMargin/test.js
+++ b/tests/content/entity/text/rightMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity rightMargin", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity rightMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/textAlpha/test.js
+++ b/tests/content/entity/text/textAlpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity textAlpha", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity textAlpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/textAlpha/test.js
+++ b/tests/content/entity/text/textAlpha/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity textAlpha", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity textAlpha", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/textColor/test.js
+++ b/tests/content/entity/text/textColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity textColor", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity textColor", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/textColor/test.js
+++ b/tests/content/entity/text/textColor/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity textColor", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity textColor", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/topMargin/test.js
+++ b/tests/content/entity/text/topMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity topMargin", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text Entity topMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/text/topMargin/test.js
+++ b/tests/content/entity/text/topMargin/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text Entity topMargin", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text Entity topMargin", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;
 

--- a/tests/content/entity/zone/ambientLightInheritance/test.js
+++ b/tests/content/entity/zone/ambientLightInheritance/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone - Ambient Light Inheritance", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Zone - Ambient Light Inheritance", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var avatarOriginPosition = nitpick.getOriginFrame();
     avatarOriginPosition = Vec3.sum(avatarOriginPosition, { x: 0.0, y: 1.0, z: 0.0 });
     

--- a/tests/content/entity/zone/ambientLightInheritance/test.js
+++ b/tests/content/entity/zone/ambientLightInheritance/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone - Ambient Light Inheritance", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Zone - Ambient Light Inheritance", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var avatarOriginPosition = nitpick.getOriginFrame();
     avatarOriginPosition = Vec3.sum(avatarOriginPosition, { x: 0.0, y: 1.0, z: 0.0 });
     

--- a/tests/content/entity/zone/create/test.js
+++ b/tests/content/entity/zone/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone create", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Zone create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Create the zone centered at the avatar position
     var pos = MyAvatar.position;
 

--- a/tests/content/entity/zone/create/test.js
+++ b/tests/content/entity/zone/create/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Zone create", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Create the zone centered at the avatar position
     var pos = MyAvatar.position;
 

--- a/tests/content/entity/zone/shadowControl/test.js
+++ b/tests/content/entity/zone/shadowControl/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow control", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Shadow control", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 120;
     var zone;
     var terrain;

--- a/tests/content/entity/zone/shadowControl/test.js
+++ b/tests/content/entity/zone/shadowControl/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow control", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Shadow control", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 120;
     var zone;
     var terrain;

--- a/tests/content/entity/zone/zoneEffects/test.js
+++ b/tests/content/entity/zone/zoneEffects/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone - Effects on Ambient Lights and Skybox", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Zone - Effects on Ambient Lights and Skybox", Script.resolvePath("."), "secondary", undefined, function(testType) {
     MyAvatar.orientation = Quat.fromPitchYawRollDegrees(0.0, 0.0, 0.0);
 
     var origin = Vec3.sum(nitpick.getOriginFrame(), { x: 0.0, y: 1.0, z: 0.0 });

--- a/tests/content/entity/zone/zoneEffects/test.js
+++ b/tests/content/entity/zone/zoneEffects/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone - Effects on Ambient Lights and Skybox", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Zone - Effects on Ambient Lights and Skybox", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     MyAvatar.orientation = Quat.fromPitchYawRollDegrees(0.0, 0.0, 0.0);
 
     var origin = Vec3.sum(nitpick.getOriginFrame(), { x: 0.0, y: 1.0, z: 0.0 });

--- a/tests/content/entity/zone/zoneOrientation/test.js
+++ b/tests/content/entity/zone/zoneOrientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone - effects of orientation", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Zone - effects of orientation", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var avatarOriginPosition = MyAvatar.position;
 
     var zonePosition = { x: avatarOriginPosition.x, y: avatarOriginPosition.y - 4.0, z: avatarOriginPosition.z - 17.5 };

--- a/tests/content/entity/zone/zoneOrientation/test.js
+++ b/tests/content/entity/zone/zoneOrientation/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone - effects of orientation", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Zone - effects of orientation", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var avatarOriginPosition = MyAvatar.position;
 
     var zonePosition = { x: avatarOriginPosition.x, y: avatarOriginPosition.y - 4.0, z: avatarOriginPosition.z - 17.5 };

--- a/tests/content/overlay/material/test.js
+++ b/tests/content/overlay/material/test.js
@@ -7,7 +7,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 // Create the material test model matrix
 // Based on: https://raw.githubusercontent.com/highfidelity/hifi_tests/master/assets/models/material_matrix_models/material_matrix.js
 
-nitpick.perform("Model Overlay Material create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Model Overlay Material create", Script.resolvePath("."), "secondary", undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/content/overlay/material/test.js
+++ b/tests/content/overlay/material/test.js
@@ -7,7 +7,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
 // Create the material test model matrix
 // Based on: https://raw.githubusercontent.com/highfidelity/hifi_tests/master/assets/models/material_matrix_models/material_matrix.js
 
-nitpick.perform("Model Overlay Material create", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Model Overlay Material create", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
 
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var LIFETIME = 200;

--- a/tests/engine/controller/reticle/testStory.js
+++ b/tests/engine/controller/reticle/testStory.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Reticle control", Script.resolvePath("."), "primary", function(testType) {
+nitpick.perform("Reticle control", Script.resolvePath("."), "primary", undefined, undefined, function(testType) {
     var zone;
     var previousReticleScale;
     var LIFETIME = 120;

--- a/tests/engine/controller/reticle/testStory.js
+++ b/tests/engine/controller/reticle/testStory.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Reticle control", Script.resolvePath("."), "primary", undefined, undefined, function(testType) {
+nitpick.perform("Reticle control", Script.resolvePath("."), "primary", undefined, function(testType) {
     var zone;
     var previousReticleScale;
     var LIFETIME = 120;

--- a/tests/engine/interaction/pick/collision/capsule_on_server/testStory.js
+++ b/tests/engine/interaction/pick/collision/capsule_on_server/testStory.js
@@ -5,7 +5,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test capsule CollisionPick on server", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test capsule CollisionPick on server", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var createdEntities = [];
     var createdPicks = [];
     var createdOverlays = [];

--- a/tests/engine/interaction/pick/collision/capsule_on_server/testStory.js
+++ b/tests/engine/interaction/pick/collision/capsule_on_server/testStory.js
@@ -5,7 +5,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test capsule CollisionPick on server", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test capsule CollisionPick on server", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var createdEntities = [];
     var createdPicks = [];
     var createdOverlays = [];

--- a/tests/engine/interaction/pick/collision/cube/test.js
+++ b/tests/engine/interaction/pick/collision/cube/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick with cubes", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test CollisionPick with cubes", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/cube/test.js
+++ b/tests/engine/interaction/pick/collision/cube/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick with cubes", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test CollisionPick with cubes", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/filter/test.js
+++ b/tests/engine/interaction/pick/collision/filter/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick pick filtering", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test CollisionPick pick filtering", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/filter/test.js
+++ b/tests/engine/interaction/pick/collision/filter/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick pick filtering", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test CollisionPick pick filtering", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/identical/test.js
+++ b/tests/engine/interaction/pick/collision/identical/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick with identical cube picks", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test CollisionPick with identical cube picks", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/identical/test.js
+++ b/tests/engine/interaction/pick/collision/identical/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick with identical cube picks", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test CollisionPick with identical cube picks", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/many/test.js
+++ b/tests/engine/interaction/pick/collision/many/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick with many cubes", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test CollisionPick with many cubes", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/many/test.js
+++ b/tests/engine/interaction/pick/collision/many/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick with many cubes", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test CollisionPick with many cubes", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/myavatar/test.js
+++ b/tests/engine/interaction/pick/collision/myavatar/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick against MyAvatar", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test CollisionPick against MyAvatar", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/myavatar/test.js
+++ b/tests/engine/interaction/pick/collision/myavatar/test.js
@@ -8,7 +8,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 // Shared script code for collision pick tests
 Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interaction/pick/collision/shared.js"));
 
-nitpick.perform("Test CollisionPick against MyAvatar", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test CollisionPick against MyAvatar", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var initData = { originFrame: nitpick.getOriginFrame() };
     var createdEntities = setupStage(initData);
     var createdPicks = [];

--- a/tests/engine/interaction/pick/collision/parenting_on_server/testStory.js
+++ b/tests/engine/interaction/pick/collision/parenting_on_server/testStory.js
@@ -9,7 +9,7 @@ Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interact
 var jointModelPath = Script.resolvePath(nitpick.getAssetsRootPath() + "/models/geometry/avatars/claire/Claire.fbx");
 var testModelJointName = "LeftToeBase";
 
-nitpick.perform("Test pick parenting on server", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test pick parenting on server", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var createdEntities = [];
     var createdPicks = [];
     var createdOverlays = [];

--- a/tests/engine/interaction/pick/collision/parenting_on_server/testStory.js
+++ b/tests/engine/interaction/pick/collision/parenting_on_server/testStory.js
@@ -9,7 +9,7 @@ Script.include(Script.resolvePath(nitpick.getTestsRootPath() + "/engine/interact
 var jointModelPath = Script.resolvePath(nitpick.getAssetsRootPath() + "/models/geometry/avatars/claire/Claire.fbx");
 var testModelJointName = "LeftToeBase";
 
-nitpick.perform("Test pick parenting on server", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test pick parenting on server", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var createdEntities = [];
     var createdPicks = [];
     var createdOverlays = [];

--- a/tests/engine/interaction/pointer/laser/centerEndY/test.js
+++ b/tests/engine/interaction/pointer/laser/centerEndY/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Laser Pointer - from centre down Y axis", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Laser Pointer - from centre down Y axis", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/centerEndY/test.js
+++ b/tests/engine/interaction/pointer/laser/centerEndY/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Laser Pointer - from centre down Y axis", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Laser Pointer - from centre down Y axis", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/distanceScaleEnd/test.js
+++ b/tests/engine/interaction/pointer/laser/distanceScaleEnd/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Size of laser end increases with distance", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Size of laser end increases with distance", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/distanceScaleEnd/test.js
+++ b/tests/engine/interaction/pointer/laser/distanceScaleEnd/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Size of laser end increases with distance", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Size of laser end increases with distance", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/enable/test.js
+++ b/tests/engine/interaction/pointer/laser/enable/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Laser - enabling and disabling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Laser - enabling and disabling", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/enable/test.js
+++ b/tests/engine/interaction/pointer/laser/enable/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Laser - enabling and disabling", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Laser - enabling and disabling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/faceAvatar/test.js
+++ b/tests/engine/interaction/pointer/laser/faceAvatar/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer faceAvatar test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("LaserPointer faceAvatar test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/faceAvatar/test.js
+++ b/tests/engine/interaction/pointer/laser/faceAvatar/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer faceAvatar test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("LaserPointer faceAvatar test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/ignore/test.js
+++ b/tests/engine/interaction/pointer/laser/ignore/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer ignore test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("LaserPointer ignore test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/ignore/test.js
+++ b/tests/engine/interaction/pointer/laser/ignore/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer ignore test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("LaserPointer ignore test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/lockEnd/test.js
+++ b/tests/engine/interaction/pointer/laser/lockEnd/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer lockEnd test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("LaserPointer lockEnd test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/lockEnd/test.js
+++ b/tests/engine/interaction/pointer/laser/lockEnd/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer lockEnd test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("LaserPointer lockEnd test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/lockEndUUID/test.js
+++ b/tests/engine/interaction/pointer/laser/lockEndUUID/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer lockEndUUID test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("LaserPointer lockEndUUID test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/lockEndUUID/test.js
+++ b/tests/engine/interaction/pointer/laser/lockEndUUID/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer lockEndUUID test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("LaserPointer lockEndUUID test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/renderState/test.js
+++ b/tests/engine/interaction/pointer/laser/renderState/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer renderState test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("LaserPointer renderState test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/laser/renderState/test.js
+++ b/tests/engine/interaction/pointer/laser/renderState/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LaserPointer renderState test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("LaserPointer renderState test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../laserPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/enable/test.js
+++ b/tests/engine/interaction/pointer/parabola/enable/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola - enabling and disabling", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Parabola - enabling and disabling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/enable/test.js
+++ b/tests/engine/interaction/pointer/parabola/enable/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola - enabling and disabling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Parabola - enabling and disabling", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/ignore/test.js
+++ b/tests/engine/interaction/pointer/parabola/ignore/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola ignore test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Parabola ignore test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/ignore/test.js
+++ b/tests/engine/interaction/pointer/parabola/ignore/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola ignore test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Parabola ignore test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/lockEnd/test.js
+++ b/tests/engine/interaction/pointer/parabola/lockEnd/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola lockEnd test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Parabola lockEnd test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/lockEnd/test.js
+++ b/tests/engine/interaction/pointer/parabola/lockEnd/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola lockEnd test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Parabola lockEnd test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/renderState/test.js
+++ b/tests/engine/interaction/pointer/parabola/renderState/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola renderState test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Parabola renderState test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/interaction/pointer/parabola/renderState/test.js
+++ b/tests/engine/interaction/pointer/parabola/renderState/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Parabola renderState test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Parabola renderState test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../parabolaPointerUtils.js?raw=true");
 
     initializeTestData(nitpick.getOriginFrame());

--- a/tests/engine/render/antialiasing/testStory.js
+++ b/tests/engine/render/antialiasing/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Anti-aliasing test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Anti-aliasing test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../material/matrix.js?raw=true")
 

--- a/tests/engine/render/antialiasing/testStory.js
+++ b/tests/engine/render/antialiasing/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Anti-aliasing test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Anti-aliasing test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../material/matrix.js?raw=true")
 

--- a/tests/engine/render/camera/primary/test.js
+++ b/tests/engine/render/camera/primary/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "primary", function(testType) {
+nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "primary", undefined, undefined, function(testType) {
     var LIFETIME = 120;
 	var createdEntities = [];
     var position = nitpick.getOriginFrame();

--- a/tests/engine/render/camera/primary/test.js
+++ b/tests/engine/render/camera/primary/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "primary", undefined, undefined, function(testType) {
+nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "primary", undefined, function(testType) {
     var LIFETIME = 120;
 	var createdEntities = [];
     var position = nitpick.getOriginFrame();

--- a/tests/engine/render/camera/secondary/test.js
+++ b/tests/engine/render/camera/secondary/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 120;
 	var createdEntities = [];
     var position = nitpick.getOriginFrame();

--- a/tests/engine/render/camera/secondary/test.js
+++ b/tests/engine/render/camera/secondary/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 120;
 	var createdEntities = [];
     var position = nitpick.getOriginFrame();

--- a/tests/engine/render/effect/bloom/test.js
+++ b/tests/engine/render/effect/bloom/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("effect - bloom", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("effect - bloom", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var pos =  nitpick.getOriginFrame();
     pos.y += 1.0;
     

--- a/tests/engine/render/effect/bloom/test.js
+++ b/tests/engine/render/effect/bloom/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("effect - bloom", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("effect - bloom", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var pos =  nitpick.getOriginFrame();
     pos.y += 1.0;
     

--- a/tests/engine/render/effect/haze/color/test.js
+++ b/tests/engine/render/effect/haze/color/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - color", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include("../setup.js?raw=true")
 
     var HAZE = {

--- a/tests/engine/render/effect/haze/color/test.js
+++ b/tests/engine/render/effect/haze/color/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - color", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - color", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include("../setup.js?raw=true")
 
     var HAZE = {

--- a/tests/engine/render/effect/haze/glare_large/test.js
+++ b/tests/engine/render/effect/haze/glare_large/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - large glare", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - large glare", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/glare_large/test.js
+++ b/tests/engine/render/effect/haze/glare_large/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - large glare", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - large glare", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/glare_small/test.js
+++ b/tests/engine/render/effect/haze/glare_small/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - small glare", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - small glare", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/glare_small/test.js
+++ b/tests/engine/render/effect/haze/glare_small/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - small glare", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - small glare", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/high_range/test.js
+++ b/tests/engine/render/effect/haze/high_range/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - high range", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - high range", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/high_range/test.js
+++ b/tests/engine/render/effect/haze/high_range/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - high range", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - high range", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range/test.js
+++ b/tests/engine/render/effect/haze/low_range/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - low range", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range/test.js
+++ b/tests/engine/render/effect/haze/low_range/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - low range", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range_high_base_low_ceiling/test.js
+++ b/tests/engine/render/effect/haze/low_range_high_base_low_ceiling/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range, low ceiling, high base (inverted haze)", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - low range, low ceiling, high base (inverted haze)", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range_high_base_low_ceiling/test.js
+++ b/tests/engine/render/effect/haze/low_range_high_base_low_ceiling/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range, low ceiling, high base (inverted haze)", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - low range, low ceiling, high base (inverted haze)", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range_high_ceiling/test.js
+++ b/tests/engine/render/effect/haze/low_range_high_ceiling/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range, high ceiling", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - low range, high ceiling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range_high_ceiling/test.js
+++ b/tests/engine/render/effect/haze/low_range_high_ceiling/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range, high ceiling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - low range, high ceiling", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range_low_ceiling/test.js
+++ b/tests/engine/render/effect/haze/low_range_low_ceiling/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range, low ceiling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - low range, low ceiling", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/low_range_low_ceiling/test.js
+++ b/tests/engine/render/effect/haze/low_range_low_ceiling/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - low range, low ceiling", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - low range, low ceiling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/none/test.js
+++ b/tests/engine/render/effect/haze/none/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - off", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - off", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/none/test.js
+++ b/tests/engine/render/effect/haze/none/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - off", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - off", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/partial_sky/test.js
+++ b/tests/engine/render/effect/haze/partial_sky/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - partially visible sky", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - partially visible sky", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/partial_sky/test.js
+++ b/tests/engine/render/effect/haze/partial_sky/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - partially visible sky", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - partially visible sky", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/visible_sky/test.js
+++ b/tests/engine/render/effect/haze/visible_sky/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - completely visible sky", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Haze - completely visible sky", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/haze/visible_sky/test.js
+++ b/tests/engine/render/effect/haze/visible_sky/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Haze - completely visible sky", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Haze - completely visible sky", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/effect/highlight/coverage/test.js
+++ b/tests/engine/render/effect/highlight/coverage/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Highlight Test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Highlight Test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var createdEntities = [];
     var createdOverlays = [];
 

--- a/tests/engine/render/effect/highlight/coverage/test.js
+++ b/tests/engine/render/effect/highlight/coverage/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Highlight Test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Highlight Test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var createdEntities = [];
     var createdOverlays = [];
 

--- a/tests/engine/render/geometry/invalidURL/test.js
+++ b/tests/engine/render/geometry/invalidURL/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Attempt to access invalid URL", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Attempt to access invalid URL", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/engine/render/geometry/invalidURL/test.js
+++ b/tests/engine/render/geometry/invalidURL/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Attempt to access invalid URL", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Attempt to access invalid URL", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/engine/render/lighting/ponctual/onTransparent/test.js
+++ b/tests/engine/render/lighting/ponctual/onTransparent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Lighting on Transparent Object", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Lighting on Transparent Object", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/engine/render/lighting/ponctual/onTransparent/test.js
+++ b/tests/engine/render/lighting/ponctual/onTransparent/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Lighting on Transparent Object", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Lighting on Transparent Object", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 

--- a/tests/engine/render/lod/entity/model/test.js
+++ b/tests/engine/render/lod/entity/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LOD test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("LOD test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var createdEntities = [];
 
     var LIFETIME = 120;

--- a/tests/engine/render/lod/entity/model/test.js
+++ b/tests/engine/render/lod/entity/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("LOD test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("LOD test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var createdEntities = [];
 
     var LIFETIME = 120;

--- a/tests/engine/render/material/albedo/test.js
+++ b/tests/engine/render/material/albedo/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Effects of albedo on various materials", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Effects of albedo on various materials", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/albedo/test.js
+++ b/tests/engine/render/material/albedo/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Effects of albedo on various materials", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Effects of albedo on various materials", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/base/test.js
+++ b/tests/engine/render/material/base/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show base effects on various materials", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Show base effects on various materials", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/base/test.js
+++ b/tests/engine/render/material/base/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show base effects on various materials", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Show base effects on various materials", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/emissive/test.js
+++ b/tests/engine/render/material/emissive/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of emmisive materials", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Show effects of emmisive materials", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/emissive/test.js
+++ b/tests/engine/render/material/emissive/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of emmisive materials", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Show effects of emmisive materials", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/normal_map/test.js
+++ b/tests/engine/render/material/normal_map/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of normal maps", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Show effects of normal maps", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/normal_map/test.js
+++ b/tests/engine/render/material/normal_map/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of normal maps", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Show effects of normal maps", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/opacity/test.js
+++ b/tests/engine/render/material/opacity/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of opacity", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Show effects of opacity", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/opacity/test.js
+++ b/tests/engine/render/material/opacity/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of opacity", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Show effects of opacity", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/roughness/test.js
+++ b/tests/engine/render/material/roughness/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of roughness", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Show effects of roughness", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/roughness/test.js
+++ b/tests/engine/render/material/roughness/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of roughness", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Show effects of roughness", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/roughness_map/test.js
+++ b/tests/engine/render/material/roughness_map/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of roughness maps", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Show effects of roughness maps", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/material/roughness_map/test.js
+++ b/tests/engine/render/material/roughness_map/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Show effects of roughness maps", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Show effects of roughness maps", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../matrix.js?raw=true")
 

--- a/tests/engine/render/mesh/MyAvatar/scale/test.js
+++ b/tests/engine/render/mesh/MyAvatar/scale/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 120;
 
     var previousSkeletonURL;

--- a/tests/engine/render/mesh/MyAvatar/scale/test.js
+++ b/tests/engine/render/mesh/MyAvatar/scale/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("MyAvatar scaling", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 120;
 
     var previousSkeletonURL;

--- a/tests/engine/render/mesh/MyAvatar/visibility/test.js
+++ b/tests/engine/render/mesh/MyAvatar/visibility/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Control MyAvatar mesh visibility", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Control MyAvatar mesh visibility", Script.resolvePath("."), "secondary", undefined, function(testType) {
     var LIFETIME = 120;
 
     var previousSkeletonURL;

--- a/tests/engine/render/mesh/MyAvatar/visibility/test.js
+++ b/tests/engine/render/mesh/MyAvatar/visibility/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Control MyAvatar mesh visibility", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Control MyAvatar mesh visibility", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     var LIFETIME = 120;
 
     var previousSkeletonURL;

--- a/tests/engine/render/shadows/front/test.js
+++ b/tests/engine/render/shadows/front/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary", [["mid,high"]], undefined, function(testType) {
+nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary", [["mid,high"]], function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/front/test.js
+++ b/tests/engine/render/shadows/front/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/front/test.js
+++ b/tests/engine/render/shadows/front/test.js
@@ -4,13 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary",
-function(testProfile) {
-    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
-    return testProfile.tier > 1;
-},
-undefined,
-function(testType) {
+nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary", [["mid,high"]], undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/front/test.js
+++ b/tests/engine/render/shadows/front/test.js
@@ -4,7 +4,13 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Shadow - light in front", Script.resolvePath("."), "secondary",
+function(testProfile) {
+    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
+    return testProfile.tier > 1;
+},
+undefined,
+function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/grazing/test.js
+++ b/tests/engine/render/shadows/grazing/test.js
@@ -4,13 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary",
-function(testProfile) {
-    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
-    return testProfile.tier > 1;
-},
-undefined,
-function(testType) {
+nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary", [["mid,high"]], undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/grazing/test.js
+++ b/tests/engine/render/shadows/grazing/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/grazing/test.js
+++ b/tests/engine/render/shadows/grazing/test.js
@@ -4,7 +4,13 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary",
+function(testProfile) {
+    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
+    return testProfile.tier > 1;
+},
+undefined,
+function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/grazing/test.js
+++ b/tests/engine/render/shadows/grazing/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary", [["mid,high"]], undefined, function(testType) {
+nitpick.perform("Shadow - light at grazing angle from left", Script.resolvePath("."), "secondary", [["mid,high"]], function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true")
 

--- a/tests/engine/render/shadows/normal/test.js
+++ b/tests/engine/render/shadows/normal/test.js
@@ -4,13 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary",
-function(testProfile) {
-    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
-    return testProfile.tier > 1;
-},
-undefined,
-function(testType) {
+nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary", [["mid,high"]], undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true");
 

--- a/tests/engine/render/shadows/normal/test.js
+++ b/tests/engine/render/shadows/normal/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary", [["mid,high"]], undefined, function(testType) {
+nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary", [["mid,high"]], function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true");
 

--- a/tests/engine/render/shadows/normal/test.js
+++ b/tests/engine/render/shadows/normal/test.js
@@ -4,7 +4,13 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary",
+function(testProfile) {
+    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
+    return testProfile.tier > 1;
+},
+undefined,
+function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true");
 

--- a/tests/engine/render/shadows/normal/test.js
+++ b/tests/engine/render/shadows/normal/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Shadow - light on top", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test material matrix
     Script.include("../setup.js?raw=true");
 

--- a/tests/engine/render/textures/TGA/test.js
+++ b/tests/engine/render/textures/TGA/test.js
@@ -7,7 +7,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js")
 
 var assetsRootPath = nitpick.getAssetsRootPath();
 
-nitpick.perform("TGA texture rendering", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("TGA texture rendering", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var position = nitpick.getOriginFrame();
 

--- a/tests/engine/render/textures/TGA/test.js
+++ b/tests/engine/render/textures/TGA/test.js
@@ -7,7 +7,7 @@ Script.include(nitpick.getUtilsRootPath() + "test_stage.js")
 
 var assetsRootPath = nitpick.getAssetsRootPath();
 
-nitpick.perform("TGA texture rendering", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("TGA texture rendering", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
     var position = nitpick.getOriginFrame();
 

--- a/tests/engine/render/textures/procedural/test.js
+++ b/tests/engine/render/textures/procedural/test.js
@@ -12,7 +12,7 @@ var testFiles = [
 
 var testState = {};
 
-nitpick.perform("Texture Rendering", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Texture Rendering", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // Test Texture Procedural
     Script.include("setup.js?raw=true")
 

--- a/tests/engine/render/textures/procedural/test.js
+++ b/tests/engine/render/textures/procedural/test.js
@@ -12,7 +12,7 @@ var testFiles = [
 
 var testState = {};
 
-nitpick.perform("Texture Rendering", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Texture Rendering", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // Test Texture Procedural
     Script.include("setup.js?raw=true")
 

--- a/tests/engine/ui/snapshot/testStory.js
+++ b/tests/engine/ui/snapshot/testStory.js
@@ -3,7 +3,7 @@ Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
-nitpick.perform("Test snapshot with no snap directory set", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Test snapshot with no snap directory set", Script.resolvePath("."), "secondary", undefined, function(testType) {
     
     var oldSnapshotsLocation;
     

--- a/tests/engine/ui/snapshot/testStory.js
+++ b/tests/engine/ui/snapshot/testStory.js
@@ -3,7 +3,7 @@ Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 Script.include(nitpick.getUtilsRootPath() + "test_stage.js");
 
-nitpick.perform("Test snapshot with no snap directory set", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Test snapshot with no snap directory set", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     
     var oldSnapshotsLocation;
     

--- a/tests/performance/graphics/triangles/testStory.js
+++ b/tests/performance/graphics/triangles/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("1 million triangles test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("1 million triangles test", Script.resolvePath("."), "secondary", undefined, function(testType) {
     const LIFETIME = 120;
 
     // entities

--- a/tests/performance/graphics/triangles/testStory.js
+++ b/tests/performance/graphics/triangles/testStory.js
@@ -2,7 +2,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PA
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("1 million triangles test", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("1 million triangles test", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     const LIFETIME = 120;
 
     // entities

--- a/tests/performance/sceneLoad/testPerformance.js
+++ b/tests/performance/sceneLoad/testPerformance.js
@@ -2,7 +2,7 @@ PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfideli
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Scene load performance", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Scene load performance", Script.resolvePath("."), "secondary", undefined, function(testType) {
     nitpick.addStep("Clear cache", function () {
         Test.clearCaches();
     });

--- a/tests/performance/sceneLoad/testPerformance.js
+++ b/tests/performance/sceneLoad/testPerformance.js
@@ -2,7 +2,7 @@ PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfideli
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 var nitpick = createNitpick(Script.resolvePath("."));
 
-nitpick.perform("Scene load performance", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Scene load performance", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     nitpick.addStep("Clear cache", function () {
         Test.clearCaches();
     });

--- a/tests/protocol/box/test.js
+++ b/tests/protocol/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Box protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Box protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/box/test.js
+++ b/tests/protocol/box/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Box protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Box protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/light/test.js
+++ b/tests/protocol/light/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Light protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Light protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/light/test.js
+++ b/tests/protocol/light/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Light protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Light protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/line/test.js
+++ b/tests/protocol/line/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Line protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Line protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/line/test.js
+++ b/tests/protocol/line/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Line protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Line protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/material/test.js
+++ b/tests/protocol/material/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Material protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/material/test.js
+++ b/tests/protocol/material/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Material protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Material protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/model/test.js
+++ b/tests/protocol/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Model protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Model protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
     
     var object;

--- a/tests/protocol/model/test.js
+++ b/tests/protocol/model/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Model protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Model protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
     
     var object;

--- a/tests/protocol/particleEffect/test.js
+++ b/tests/protocol/particleEffect/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Particle effect protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Particle effect protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/particleEffect/test.js
+++ b/tests/protocol/particleEffect/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Particle effect protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Particle effect protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/polyline/test.js
+++ b/tests/protocol/polyline/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("PolyLine protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("PolyLine protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/polyline/test.js
+++ b/tests/protocol/polyline/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("PolyLine protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("PolyLine protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/polyvox/test.js
+++ b/tests/protocol/polyvox/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyvox protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Polyvox protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/polyvox/test.js
+++ b/tests/protocol/polyvox/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Polyvox protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Polyvox protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/sphere/test.js
+++ b/tests/protocol/sphere/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Sphere protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Sphere protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/sphere/test.js
+++ b/tests/protocol/sphere/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Sphere protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Sphere protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/text/test.js
+++ b/tests/protocol/text/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Text protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/text/test.js
+++ b/tests/protocol/text/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Text protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Text protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/zone/test.js
+++ b/tests/protocol/zone/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("Zone protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/protocol/zone/test.js
+++ b/tests/protocol/zone/test.js
@@ -4,7 +4,7 @@ if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
     nitpick = createNitpick(Script.resolvePath("."));
 }
 
-nitpick.perform("Zone protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("Zone protocol sanity - TEST REQUIRES SERVER", Script.resolvePath("."), "secondary", undefined, function(testType) {
     Script.include('../common.js');
 
     var object;

--- a/tests/utils/README.md
+++ b/tests/utils/README.md
@@ -39,7 +39,7 @@ A test case consists of initialization code followed by a series of steps. In ge
 
 It is suggested to set the following properties for all entities:
 * lifetime: 60,
-* position: Vec3.sum(MyAvatar.position, *some offset*),
+* position: Vec3.sum(MyAvatar.position, some offset*),
 * userData: JSON.stringify({ grabbableKey: { grabbable: false } })
 
 ### Origin Frame
@@ -83,9 +83,15 @@ Each test folder has (at least) 3 scripts and a number of images.
 The expected images themselves are created in 2 stages:  running the test and then running `nitpick.exe` to create the images from the test results.
 
 ### Boilerplate
-The first 2 lines define the GitHub repository.  This allows changing the repository for testing purposes.
+The boilerplate code is enclosed in an if statement to ensure it is only called once.
 ```
-if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/utils/branchUtils.js";
+if (typeof PATH_TO_THE_REPO_PATH_UTILS_FILE === 'undefined') {
+    // Boilerplate code
+}
+```
+The first 2 lines of the boilerplate code define the GitHub repository.  This allows changing the repository for testing purposes.
+```
+PATH_TO_THE_REPO_PATH_UTILS_FILE = "https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/utils/branchUtils.js";
 Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);
 ```
 The next line loads the nitpick script (the script contains a module)
@@ -94,7 +100,7 @@ var nitpick = createAutoTester(Script.resolvePath("."));
 ```
 The test itself is written in the perform method:
 ```
-nitpick.perform("<test description string>", Script.resolvePath("."), "secondary", function(testType) {
+nitpick.perform("<test description string>", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
     // set up zones, objects and other entities 
     
     // create steps
@@ -103,6 +109,16 @@ nitpick.perform("<test description string>", Script.resolvePath("."), "secondary
 });    
 ```
 Note that "secondary" may be replaced by "primary".  This is needed for tests that require the primary camera.
+
+The first parameter that is marked `undefined` can optionally be replaced with a function `shouldRun` that takes a `TestProfile` object and returns `true` if the test should be allowed to run. The `TestProfile` object provides these parameters: `tier`, `os`, and `gpu`. Consider, as an example, this `shouldRun` function from a shadow test, which cannot run when shadows are disabled:
+```
+function(testProfile) {
+    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
+    return testProfile.tier > 1;
+}
+```
+
+The second `undefined` parameter is reserved for future use.
 
 The **`nitpick.runTest(testType);`** call is the line that requests the execution of the steps.  
 As described above, steps usually come in pairs.  

--- a/tests/utils/README.md
+++ b/tests/utils/README.md
@@ -100,7 +100,7 @@ var nitpick = createAutoTester(Script.resolvePath("."));
 ```
 The test itself is written in the perform method:
 ```
-nitpick.perform("<test description string>", Script.resolvePath("."), "secondary", undefined, undefined, function(testType) {
+nitpick.perform("<test description string>", Script.resolvePath("."), "secondary", undefined, function(testType) {
     // set up zones, objects and other entities 
     
     // create steps
@@ -110,15 +110,7 @@ nitpick.perform("<test description string>", Script.resolvePath("."), "secondary
 ```
 Note that "secondary" may be replaced by "primary".  This is needed for tests that require the primary camera.
 
-The first parameter that is marked `undefined` can optionally be replaced with a function `shouldRun` that takes a `TestProfile` object and returns `true` if the test should be allowed to run. The `TestProfile` object provides these parameters: `tier`, `os`, and `gpu`. Consider, as an example, this `shouldRun` function from a shadow test, which cannot run when shadows are disabled:
-```
-function(testProfile) {
-    // Only run on mid tier or higher, which uses deferred rendering and therefore supports shadows.
-    return testProfile.tier > 1;
-}
-```
-
-The second `undefined` parameter is reserved for future use.
+The next parameter that is marked `undefined` can optionally be replaced with a list of one or more filters, indicating when the test should run. This uses a special syntax which is explained in a later section.
 
 The **`nitpick.runTest(testType);`** call is the line that requests the execution of the steps.  
 As described above, steps usually come in pairs.  
@@ -135,6 +127,29 @@ The following is an example showing the idea:
     nitpick.addStepSnapshot("Blue zone, dark ambient light");
 ```
 The first step moves forward 10 metres (the avatar is looking *down* the Z axis).
+
+### Test Filtering
+
+As previously mentioned, the test boilerplate contains an `undefined` parameter after the "secondary"/"primary" camera option. This allows the test creator to determine when the test is run. For example, the parameter could be replaced by `[["high"]]` to indicate that the test should only run when the current performance tier for Interface is set to High.
+
+Some more examples are included below:
+```
+[["mac"]] /* Run only on Mac */
+[["mac.amd"]] /* Run only on Mac with an AMD GPU */
+[["mid,high"]] /* Run only on the mid/high performance tier */
+[["windows,mac,linux.amd,nvidia"]] /* Run only on Windows/Mac/Linux AND run only when AMD or Nvidia GPU present */
+[["low,mid.windows"], ["android"], ["mac.intel"]] /* Run on either: 1) Windows in low/mid performance tier, 2) Android, or 3) A Mac with Intel GPU */
+```
+The filter syntax works as follows:
+- Each inner pair of square brackets is a filter. If the current test profile (combination of tier, OS, and GPU) matches at least one of the filters, then the test will be run.
+- Multiple filters are separated by commas per standard javascript list syntax
+- Each filter consists of a filter string (additional parameters may be added later)
+- The filter string can contain one or more restrictions, separated by periods (`.`). All restrictions must match for the filter to match the test profile. Possible restrictions are:
+  - For tier: `low`, `mid`, `high`
+  - For OS: `windows`, `mac`, `linux`, `android`
+  - For GPU: `amd`, `nvidia`, `intel`
+- Each restriction can optionally be made broader. Rather than specifying only one tier/OS/GPU, multiple valid options can be separated by commas (`,`).
+
 ### `nitpick.js` function documentation
 #### `perform` method
 `nitpick.js` provides the **`perform`** method, used in all tests.  This method accepts 4 parameters:

--- a/tests/utils/nitpick.js
+++ b/tests/utils/nitpick.js
@@ -661,7 +661,7 @@ getTestProfile = function() {
 //
 // The method creates a test case in currentTestCase.
 // If the test mode is manual or auto then its execution is started
-module.exports.perform = function (testName, testPath, validationCamera, runFiltersRaw, unused, testMain) {
+module.exports.perform = function (testName, testPath, validationCamera, runFiltersRaw, testMain) {
     var usePrimaryCamera = (validationCamera === "primary");
     currentTestCase = new TestCase(testName, testPath, testMain, usePrimaryCamera, runFiltersRaw);
 

--- a/tests/utils/nitpick.js
+++ b/tests/utils/nitpick.js
@@ -101,12 +101,21 @@ RunFilter.createRunFilter = function(testCaseName, runFilterArgs) {
     var whitelistPerProperty = whitelistString.split(".");
     for (var j = 0; j < whitelistPerProperty.length; j++) {
         var propertyWhitelistString = whitelistPerProperty[j];
+        if (propertyWhitelistString === "") {
+            continue;
+        }
+        
         var whitelistedOptionsPerProperty = propertyWhitelistString.split(",");
+        var validWhitelistedOptionsPerProperty = [];
         var profileCategory = undefined;
         var previousProfileCategory = undefined;
         // Check all properties. Complain if one is not correct.
         for (var k = 0; k < whitelistedOptionsPerProperty.length; k++) {
             var whitelistedPropertyOption = whitelistedOptionsPerProperty[k];
+            if (whitelistedPropertyOption === "") {
+                continue;
+            }
+            
             profileCategory = PROPERTY_TO_PROFILE_CATEGORY[whitelistedPropertyOption];
             if (profileCategory === undefined) {
                 logAndNotify("Unrecognized test profile property '" + whitelistedPropertyOption + "' when creating test '" + testCaseName + "'");
@@ -117,9 +126,12 @@ RunFilter.createRunFilter = function(testCaseName, runFilterArgs) {
                 return RunFilter.createGlobalBlacklistFilter();
             }
             previousProfileCategory = profileCategory;
+            validWhitelistedOptionsPerProperty.push(whitelistedPropertyOption);
         }
         // All properties are valid!
-        allowedPerProperty[profileCategory] = whitelistedOptionsPerProperty;
+        if (profileCategory !== undefined) {
+            allowedPerProperty[profileCategory] = validWhitelistedOptionsPerProperty;
+        }
     }
     
     // An empty allowedPerProperty is allowed and acts as a global wildcard


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-359

This PR:
- Adds an optional parameter to `nitpick.perform` which lets tests limit what profiles they should run on. This parameter uses a special syntax described [here](https://github.com/sabrina-shanman/hifi_tests/tree/test-profile/tests/utils#test-filtering).
- Makes `tests/engine/render/shadow` tests disabled on low tier